### PR TITLE
ci(lint): drop gosec — security owned by nox

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # klarlabs-studio Go lint bar (golangci-lint v2). Tracks the org golden
-# config (.github/golangci.reference.yml): gocritic + gosec are mandatory
-# and the formatters (gofmt/goimports) are part of the gate. Repo-specific
-# exclusions live under exclusions.rules.
+# config (.github/golangci.reference.yml): gocritic is mandatory and the
+# formatters (gofmt/goimports) are part of the gate; code-level security is
+# owned by nox. Repo-specific exclusions live under exclusions.rules.
 version: "2"
 
 run:
@@ -21,7 +21,6 @@ linters:
     - unconvert
     - unparam
     - gocritic     # org engineering bar — do not drop
-    - gosec
 
   settings:
     errcheck:
@@ -47,7 +46,6 @@ linters:
       # readability).
       - path: _test\.go
         linters:
-          - gosec
           - errcheck
           - unparam
       # Examples prioritize readability over exhaustive error handling.

--- a/contrib/pack-archive/archive.go
+++ b/contrib/pack-archive/archive.go
@@ -155,7 +155,6 @@ func (p *archivePack) createZipTool() tool.Tool {
 						return fmt.Errorf("failed to create entry: %w", err)
 					}
 
-					// #nosec G304 -- File path from user input is intentional for archive tool
 					f, err := os.Open(path)
 					if err != nil {
 						return fmt.Errorf("failed to open file: %w", err)
@@ -182,7 +181,7 @@ func (p *archivePack) createZipTool() tool.Tool {
 				"total_size": totalSize,
 				"success":    true,
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -211,7 +210,6 @@ func (p *archivePack) extractZipTool() tool.Tool {
 			}
 			defer reader.Close()
 
-			// #nosec G301 -- Directory permissions 0755 are intentional for user-accessible directories
 			if err := os.MkdirAll(params.Output, 0755); err != nil {
 				return tool.Result{}, fmt.Errorf("failed to create output dir: %w", err)
 			}
@@ -225,13 +223,13 @@ func (p *archivePack) extractZipTool() tool.Tool {
 				}
 
 				// Validate path to prevent zip slip attacks
-				destPath := filepath.Join(params.Output, filepath.Clean(file.Name)) // #nosec G305 -- Path validated by isPathSafe using filepath.Rel
+				destPath := filepath.Join(params.Output, filepath.Clean(file.Name))
 				if !isPathSafe(params.Output, destPath) {
 					continue // Skip files that would escape the output directory
 				}
 
 				if file.FileInfo().IsDir() {
-					_ = os.MkdirAll(destPath, file.Mode()) // #nosec G104 -- Best effort directory creation
+					_ = os.MkdirAll(destPath, file.Mode())
 					continue
 				}
 
@@ -239,17 +237,14 @@ func (p *archivePack) extractZipTool() tool.Tool {
 				if file.UncompressedSize64 > math.MaxInt64 {
 					continue // Skip files with size that would overflow int64
 				}
-				// #nosec G115 -- Overflow checked above with math.MaxInt64 comparison
 				if p.cfg.MaxFileSize > 0 && int64(file.UncompressedSize64) > p.cfg.MaxFileSize {
 					continue // Skip files that are too large
 				}
 
-				// #nosec G301 -- Directory permissions 0755 are intentional for user-accessible directories
 				if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
 					return tool.Result{}, fmt.Errorf("failed to create dir: %w", err)
 				}
 
-				// #nosec G304 -- destPath is validated by isPathSafe to prevent traversal
 				destFile, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
 				if err != nil {
 					return tool.Result{}, fmt.Errorf("failed to create file: %w", err)
@@ -257,14 +252,13 @@ func (p *archivePack) extractZipTool() tool.Tool {
 
 				srcFile, err := file.Open()
 				if err != nil {
-					_ = destFile.Close() // #nosec G104 -- Best effort cleanup
+					_ = destFile.Close()
 					return tool.Result{}, fmt.Errorf("failed to open zip entry: %w", err)
 				}
 
-				// #nosec G110 -- Decompression size is bounded by MaxFileSize config and header size check above
 				written, err := io.Copy(destFile, srcFile)
-				_ = srcFile.Close()  // #nosec G104 -- Best effort cleanup
-				_ = destFile.Close() // #nosec G104 -- Best effort cleanup
+				_ = srcFile.Close()
+				_ = destFile.Close()
 				if err != nil {
 					return tool.Result{}, fmt.Errorf("failed to extract file: %w", err)
 				}
@@ -279,7 +273,7 @@ func (p *archivePack) extractZipTool() tool.Tool {
 				"total_size": totalSize,
 				"success":    true,
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -327,7 +321,7 @@ func (p *archivePack) listZipTool() tool.Tool {
 				"file_count": len(files),
 				"total_size": totalSize,
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -360,7 +354,7 @@ func (p *archivePack) addToZipTool() tool.Tool {
 			// Create temp file for new archive
 			tempFile, err := os.CreateTemp(p.cfg.TempDir, "archive-*.zip")
 			if err != nil {
-				_ = existingReader.Close() // #nosec G104 -- Best effort cleanup
+				_ = existingReader.Close()
 				return tool.Result{}, fmt.Errorf("failed to create temp file: %w", err)
 			}
 			tempPath := tempFile.Name()
@@ -372,34 +366,33 @@ func (p *archivePack) addToZipTool() tool.Tool {
 				header := file.FileHeader
 				writer, err := zipWriter.CreateHeader(&header)
 				if err != nil {
-					_ = zipWriter.Close()      // #nosec G104 -- Best effort cleanup
-					_ = tempFile.Close()       // #nosec G104 -- Best effort cleanup
-					_ = existingReader.Close() // #nosec G104 -- Best effort cleanup
-					_ = os.Remove(tempPath)    // #nosec G104 -- Best effort cleanup
+					_ = zipWriter.Close()
+					_ = tempFile.Close()
+					_ = existingReader.Close()
+					_ = os.Remove(tempPath)
 					return tool.Result{}, fmt.Errorf("failed to create header: %w", err)
 				}
 
 				reader, err := file.Open()
 				if err != nil {
-					_ = zipWriter.Close()      // #nosec G104 -- Best effort cleanup
-					_ = tempFile.Close()       // #nosec G104 -- Best effort cleanup
-					_ = existingReader.Close() // #nosec G104 -- Best effort cleanup
-					_ = os.Remove(tempPath)    // #nosec G104 -- Best effort cleanup
+					_ = zipWriter.Close()
+					_ = tempFile.Close()
+					_ = existingReader.Close()
+					_ = os.Remove(tempPath)
 					return tool.Result{}, fmt.Errorf("failed to open file: %w", err)
 				}
 
-				// #nosec G110 -- Copying existing archive entries - size bounded by original archive
 				_, err = io.Copy(writer, reader)
-				_ = reader.Close() // #nosec G104 -- Best effort cleanup
+				_ = reader.Close()
 				if err != nil {
-					_ = zipWriter.Close()      // #nosec G104 -- Best effort cleanup
-					_ = tempFile.Close()       // #nosec G104 -- Best effort cleanup
-					_ = existingReader.Close() // #nosec G104 -- Best effort cleanup
-					_ = os.Remove(tempPath)    // #nosec G104 -- Best effort cleanup
+					_ = zipWriter.Close()
+					_ = tempFile.Close()
+					_ = existingReader.Close()
+					_ = os.Remove(tempPath)
 					return tool.Result{}, fmt.Errorf("failed to copy file: %w", err)
 				}
 			}
-			_ = existingReader.Close() // #nosec G104 -- Best effort cleanup
+			_ = existingReader.Close()
 
 			// Add new files
 			addedCount := 0
@@ -436,26 +429,25 @@ func (p *archivePack) addToZipTool() tool.Tool {
 					continue
 				}
 
-				// #nosec G304 -- File path from user input is intentional for archive tool
 				f, err := os.Open(file)
 				if err != nil {
 					continue
 				}
 
 				_, err = io.Copy(writer, f)
-				_ = f.Close() // #nosec G104 -- Best effort cleanup
+				_ = f.Close()
 				if err != nil {
 					continue
 				}
 				addedCount++
 			}
 
-			_ = zipWriter.Close() // #nosec G104 -- Best effort cleanup
-			_ = tempFile.Close()  // #nosec G104 -- Best effort cleanup
+			_ = zipWriter.Close()
+			_ = tempFile.Close()
 
 			// Replace original with temp
 			if err := os.Rename(tempPath, params.Archive); err != nil {
-				_ = os.Remove(tempPath) // #nosec G104 -- Best effort cleanup
+				_ = os.Remove(tempPath)
 				return tool.Result{}, fmt.Errorf("failed to replace archive: %w", err)
 			}
 
@@ -464,7 +456,7 @@ func (p *archivePack) addToZipTool() tool.Tool {
 				"files_added": addedCount,
 				"success":     true,
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -502,7 +494,6 @@ func (p *archivePack) extractZipFileTool() tool.Tool {
 						return tool.Result{}, fmt.Errorf("unsafe output path: %s", params.Output)
 					}
 
-					// #nosec G301 -- Directory permissions 0755 are intentional for user-accessible directories
 					if err := os.MkdirAll(filepath.Dir(params.Output), 0755); err != nil {
 						return tool.Result{}, fmt.Errorf("failed to create dir: %w", err)
 					}
@@ -519,7 +510,6 @@ func (p *archivePack) extractZipFileTool() tool.Tool {
 					}
 					defer srcFile.Close()
 
-					// #nosec G110 -- Single file extraction - size bounded by MaxFileSize if configured
 					written, err := io.Copy(destFile, srcFile)
 					if err != nil {
 						return tool.Result{}, fmt.Errorf("failed to extract: %w", err)
@@ -530,7 +520,7 @@ func (p *archivePack) extractZipFileTool() tool.Tool {
 						"size":    written,
 						"success": true,
 					}
-					output, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+					output, _ := json.Marshal(result)
 					return tool.Result{Output: output}, nil
 				}
 			}
@@ -602,7 +592,6 @@ func (p *archivePack) createTarTool() tool.Tool {
 						return nil
 					}
 
-					// #nosec G304 -- File path from user input is intentional for archive tool
 					f, err := os.Open(path)
 					if err != nil {
 						return fmt.Errorf("failed to open file: %w", err)
@@ -629,7 +618,7 @@ func (p *archivePack) createTarTool() tool.Tool {
 				"total_size": totalSize,
 				"success":    true,
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -660,7 +649,6 @@ func (p *archivePack) extractTarTool() tool.Tool {
 
 			tarReader := tar.NewReader(tarFile)
 
-			// #nosec G301 -- Directory permissions 0755 are intentional for user-accessible directories
 			if err := os.MkdirAll(params.Output, 0755); err != nil {
 				return tool.Result{}, fmt.Errorf("failed to create output dir: %w", err)
 			}
@@ -682,14 +670,13 @@ func (p *archivePack) extractTarTool() tool.Tool {
 				}
 
 				// Validate path to prevent path traversal attacks
-				destPath := filepath.Join(params.Output, filepath.Clean(header.Name)) // #nosec G305 -- Path validated by isPathSafe using filepath.Rel
+				destPath := filepath.Join(params.Output, filepath.Clean(header.Name))
 				if !isPathSafe(params.Output, destPath) {
 					continue
 				}
 
 				switch header.Typeflag {
 				case tar.TypeDir:
-					// #nosec G115 -- header.Mode is int64, masking with 0777 ensures safe conversion to uint32
 					if err := os.MkdirAll(destPath, os.FileMode(header.Mode&0777)); err != nil {
 						return tool.Result{}, fmt.Errorf("failed to create dir: %w", err)
 					}
@@ -698,20 +685,17 @@ func (p *archivePack) extractTarTool() tool.Tool {
 						continue
 					}
 
-					// #nosec G301 -- Directory permissions 0755 are intentional for user-accessible directories
 					if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
 						return tool.Result{}, fmt.Errorf("failed to create dir: %w", err)
 					}
 
-					// #nosec G115 G304 -- Mode masked with 0777; destPath validated by isPathSafe
 					destFile, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(header.Mode&0777))
 					if err != nil {
 						return tool.Result{}, fmt.Errorf("failed to create file: %w", err)
 					}
 
-					// #nosec G110 -- Decompression size is bounded by MaxFileSize config check above
 					written, err := io.Copy(destFile, tarReader)
-					_ = destFile.Close() // #nosec G104 -- Best effort cleanup
+					_ = destFile.Close()
 					if err != nil {
 						return tool.Result{}, fmt.Errorf("failed to extract file: %w", err)
 					}
@@ -727,7 +711,7 @@ func (p *archivePack) extractTarTool() tool.Tool {
 				"total_size": totalSize,
 				"success":    true,
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -795,7 +779,7 @@ func (p *archivePack) listTarTool() tool.Tool {
 				"file_count": len(files),
 				"total_size": totalSize,
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -840,7 +824,6 @@ func (p *archivePack) gzipCompressTool() tool.Tool {
 				return tool.Result{}, fmt.Errorf("failed to stat input: %w", err)
 			}
 
-			// #nosec G304 -- Output path from user input is intentional for archive tool
 			outputFile, err := os.Create(output)
 			if err != nil {
 				return tool.Result{}, fmt.Errorf("failed to create output: %w", err)
@@ -854,10 +837,10 @@ func (p *archivePack) gzipCompressTool() tool.Tool {
 			gzipWriter.Name = filepath.Base(params.Input)
 
 			if _, err := io.Copy(gzipWriter, inputFile); err != nil {
-				_ = gzipWriter.Close() // #nosec G104 -- Best effort cleanup
+				_ = gzipWriter.Close()
 				return tool.Result{}, fmt.Errorf("failed to compress: %w", err)
 			}
-			_ = gzipWriter.Close() // #nosec G104 -- Best effort cleanup
+			_ = gzipWriter.Close()
 
 			outputInfo, err := os.Stat(output)
 			if err != nil {
@@ -873,7 +856,7 @@ func (p *archivePack) gzipCompressTool() tool.Tool {
 				"compression_ratio": fmt.Sprintf("%.1f%%", ratio),
 				"success":           true,
 			}
-			resultOutput, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+			resultOutput, _ := json.Marshal(result)
 			return tool.Result{Output: resultOutput}, nil
 		}).
 		MustBuild()
@@ -916,14 +899,12 @@ func (p *archivePack) gzipDecompressTool() tool.Tool {
 			}
 			defer gzipReader.Close()
 
-			// #nosec G304 -- Output path from user input is intentional for archive tool
 			outputFile, err := os.Create(output)
 			if err != nil {
 				return tool.Result{}, fmt.Errorf("failed to create output: %w", err)
 			}
 			defer outputFile.Close()
 
-			// #nosec G110 -- Decompression size is bounded by MaxFileSize if configured, tool intentionally handles large files
 			written, err := io.Copy(outputFile, gzipReader)
 			if err != nil {
 				return tool.Result{}, fmt.Errorf("failed to decompress: %w", err)
@@ -934,7 +915,7 @@ func (p *archivePack) gzipDecompressTool() tool.Tool {
 				"size":    written,
 				"success": true,
 			}
-			resultOutput, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+			resultOutput, _ := json.Marshal(result)
 			return tool.Result{Output: resultOutput}, nil
 		}).
 		MustBuild()
@@ -1014,7 +995,6 @@ func (p *archivePack) createTarGzTool() tool.Tool {
 						return nil
 					}
 
-					// #nosec G304 -- File path from user input is intentional for archive tool
 					f, err := os.Open(path)
 					if err != nil {
 						return fmt.Errorf("failed to open file: %w", err)
@@ -1041,7 +1021,7 @@ func (p *archivePack) createTarGzTool() tool.Tool {
 				"total_size": totalSize,
 				"success":    true,
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -1078,7 +1058,6 @@ func (p *archivePack) extractTarGzTool() tool.Tool {
 
 			tarReader := tar.NewReader(gzipReader)
 
-			// #nosec G301 -- Directory permissions 0755 are intentional for user-accessible directories
 			if err := os.MkdirAll(params.Output, 0755); err != nil {
 				return tool.Result{}, fmt.Errorf("failed to create output dir: %w", err)
 			}
@@ -1100,14 +1079,13 @@ func (p *archivePack) extractTarGzTool() tool.Tool {
 				}
 
 				// Validate path to prevent path traversal attacks
-				destPath := filepath.Join(params.Output, filepath.Clean(header.Name)) // #nosec G305 -- Path validated by isPathSafe using filepath.Rel
+				destPath := filepath.Join(params.Output, filepath.Clean(header.Name))
 				if !isPathSafe(params.Output, destPath) {
 					continue
 				}
 
 				switch header.Typeflag {
 				case tar.TypeDir:
-					// #nosec G115 -- header.Mode is int64, masking with 0777 ensures safe conversion to uint32
 					if err := os.MkdirAll(destPath, os.FileMode(header.Mode&0777)); err != nil {
 						return tool.Result{}, fmt.Errorf("failed to create dir: %w", err)
 					}
@@ -1116,20 +1094,17 @@ func (p *archivePack) extractTarGzTool() tool.Tool {
 						continue
 					}
 
-					// #nosec G301 -- Directory permissions 0755 are intentional for user-accessible directories
 					if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
 						return tool.Result{}, fmt.Errorf("failed to create dir: %w", err)
 					}
 
-					// #nosec G115 G304 -- Mode masked with 0777; destPath validated by isPathSafe
 					destFile, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(header.Mode&0777))
 					if err != nil {
 						return tool.Result{}, fmt.Errorf("failed to create file: %w", err)
 					}
 
-					// #nosec G110 -- Decompression size is bounded by MaxFileSize config check above
 					written, err := io.Copy(destFile, tarReader)
-					_ = destFile.Close() // #nosec G104 -- Best effort cleanup
+					_ = destFile.Close()
 					if err != nil {
 						return tool.Result{}, fmt.Errorf("failed to extract file: %w", err)
 					}
@@ -1145,7 +1120,7 @@ func (p *archivePack) extractTarGzTool() tool.Tool {
 				"total_size": totalSize,
 				"success":    true,
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -1219,7 +1194,7 @@ func (p *archivePack) listTarGzTool() tool.Tool {
 				"file_count": len(files),
 				"total_size": totalSize,
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- Marshal of simple map cannot fail
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()

--- a/contrib/pack-collection/collection.go
+++ b/contrib/pack-collection/collection.go
@@ -188,9 +188,9 @@ func shuffleTool() tool.Tool {
 
 			var rng *rand.Rand
 			if params.Seed != 0 {
-				rng = rand.New(rand.NewSource(params.Seed)) // #nosec G404 -- math/rand sufficient for shuffling
+				rng = rand.New(rand.NewSource(params.Seed))
 			} else {
-				rng = rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec G404 -- math/rand sufficient for shuffling
+				rng = rand.New(rand.NewSource(time.Now().UnixNano()))
 			}
 
 			rng.Shuffle(len(shuffled), func(i, j int) {
@@ -231,9 +231,9 @@ func sampleTool() tool.Tool {
 
 			var rng *rand.Rand
 			if params.Seed != 0 {
-				rng = rand.New(rand.NewSource(params.Seed)) // #nosec G404 -- math/rand sufficient for sampling
+				rng = rand.New(rand.NewSource(params.Seed))
 			} else {
-				rng = rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec G404 -- math/rand sufficient for sampling
+				rng = rand.New(rand.NewSource(time.Now().UnixNano()))
 			}
 
 			// Fisher-Yates partial shuffle

--- a/contrib/pack-color/color.go
+++ b/contrib/pack-color/color.go
@@ -574,7 +574,7 @@ func hexToRGB(hex string) (int, int, int, error) {
 	g, _ := strconv.ParseUint(hex[2:4], 16, 8)
 	b, _ := strconv.ParseUint(hex[4:6], 16, 8)
 
-	return int(r), int(g), int(b), nil // #nosec G115 -- values are hex color components (0-255)
+	return int(r), int(g), int(b), nil
 }
 
 func normalizeHex(hex string) string {

--- a/contrib/pack-compression/compression.go
+++ b/contrib/pack-compression/compression.go
@@ -415,7 +415,7 @@ func detectTool() tool.Tool {
 					// Try deflate
 					reader := flate.NewReader(bytes.NewReader(data))
 					_, err := io.ReadAll(reader)
-					_ = reader.Close() // #nosec G104 -- best-effort close
+					_ = reader.Close()
 					if err == nil {
 						format = "deflate"
 						valid = true
@@ -495,22 +495,22 @@ func compareTool() tool.Tool {
 			// Try gzip
 			var gzipBuf bytes.Buffer
 			gzipWriter := gzip.NewWriter(&gzipBuf)
-			_, _ = gzipWriter.Write([]byte(params.Data)) // #nosec G104 -- comparison tool, errors don't affect result validity
-			_ = gzipWriter.Close()                       // #nosec G104
+			_, _ = gzipWriter.Write([]byte(params.Data))
+			_ = gzipWriter.Close()
 			gzipSize := gzipBuf.Len()
 
 			// Try zlib
 			var zlibBuf bytes.Buffer
 			zlibWriter := zlib.NewWriter(&zlibBuf)
-			_, _ = zlibWriter.Write([]byte(params.Data)) // #nosec G104 -- comparison tool, errors don't affect result validity
-			_ = zlibWriter.Close()                       // #nosec G104
+			_, _ = zlibWriter.Write([]byte(params.Data))
+			_ = zlibWriter.Close()
 			zlibSize := zlibBuf.Len()
 
 			// Try deflate
 			var deflateBuf bytes.Buffer
 			deflateWriter, _ := flate.NewWriter(&deflateBuf, flate.DefaultCompression)
-			_, _ = deflateWriter.Write([]byte(params.Data)) // #nosec G104 -- comparison tool, errors don't affect result validity
-			_ = deflateWriter.Close()                       // #nosec G104
+			_, _ = deflateWriter.Write([]byte(params.Data))
+			_ = deflateWriter.Close()
 			deflateSize := deflateBuf.Len()
 
 			// Find best
@@ -579,22 +579,22 @@ func benchmarkTool() tool.Tool {
 					var w *gzip.Writer
 					w, err = gzip.NewWriterLevel(&buf, level)
 					if err == nil {
-						_, _ = w.Write([]byte(params.Data)) // #nosec G104 -- benchmark tool, errors don't affect result validity
-						_ = w.Close()                       // #nosec G104
+						_, _ = w.Write([]byte(params.Data))
+						_ = w.Close()
 					}
 				case "zlib":
 					var w *zlib.Writer
 					w, err = zlib.NewWriterLevel(&buf, level)
 					if err == nil {
-						_, _ = w.Write([]byte(params.Data)) // #nosec G104 -- benchmark tool, errors don't affect result validity
-						_ = w.Close()                       // #nosec G104
+						_, _ = w.Write([]byte(params.Data))
+						_ = w.Close()
 					}
 				case "deflate":
 					var w *flate.Writer
 					w, err = flate.NewWriter(&buf, level)
 					if err == nil {
-						_, _ = w.Write([]byte(params.Data)) // #nosec G104 -- benchmark tool, errors don't affect result validity
-						_ = w.Close()                       // #nosec G104
+						_, _ = w.Write([]byte(params.Data))
+						_ = w.Close()
 					}
 				}
 

--- a/contrib/pack-crypto/crypto.go
+++ b/contrib/pack-crypto/crypto.go
@@ -6,10 +6,10 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
-	"crypto/md5" // #nosec G501 -- MD5 is used for checksum/fingerprinting purposes, not for security
+	"crypto/md5"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1" // #nosec G505 -- SHA1 is used for checksum/fingerprinting purposes, not for security
+	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
 	"crypto/x509"
@@ -98,9 +98,9 @@ func (p *cryptoPack) hashTool() tool.Tool {
 			var h hash.Hash
 			switch algorithm {
 			case "md5":
-				h = md5.New() // #nosec G401 -- MD5 is used for checksum/fingerprinting purposes, not for security
+				h = md5.New()
 			case "sha1":
-				h = sha1.New() // #nosec G401 -- SHA1 is used for checksum/fingerprinting purposes, not for security
+				h = sha1.New()
 			case "sha256":
 				h = sha256.New()
 			case "sha512":
@@ -165,9 +165,9 @@ func (p *cryptoPack) hashFileTool() tool.Tool {
 			var h hash.Hash
 			switch algorithm {
 			case "md5":
-				h = md5.New() // #nosec G401 -- MD5 is used for checksum/fingerprinting purposes, not for security
+				h = md5.New()
 			case "sha1":
-				h = sha1.New() // #nosec G401 -- SHA1 is used for checksum/fingerprinting purposes, not for security
+				h = sha1.New()
 			case "sha256":
 				h = sha256.New()
 			case "sha512":
@@ -176,7 +176,7 @@ func (p *cryptoPack) hashFileTool() tool.Tool {
 				return tool.Result{}, fmt.Errorf("unsupported algorithm: %s", algorithm)
 			}
 
-			file, err := os.Open(params.Path) // #nosec G304 -- This is a file hashing tool; path is provided by user input
+			file, err := os.Open(params.Path)
 			if err != nil {
 				return tool.Result{}, fmt.Errorf("failed to open file: %w", err)
 			}
@@ -859,9 +859,9 @@ func (p *cryptoPack) checksumTool() tool.Tool {
 				var h hash.Hash
 				switch algorithm {
 				case "md5":
-					h = md5.New() // #nosec G401 -- MD5 is used for checksum/fingerprinting purposes, not for security
+					h = md5.New()
 				case "sha1":
-					h = sha1.New() // #nosec G401 -- SHA1 is used for checksum/fingerprinting purposes, not for security
+					h = sha1.New()
 				case "sha256":
 					h = sha256.New()
 				case "sha512":
@@ -870,18 +870,18 @@ func (p *cryptoPack) checksumTool() tool.Tool {
 					return tool.Result{}, fmt.Errorf("unsupported algorithm: %s", algorithm)
 				}
 
-				file, err := os.Open(path) // #nosec G304 -- This is a checksum tool; path is provided by user input
+				file, err := os.Open(path)
 				if err != nil {
 					checksums[path] = fmt.Sprintf("error: %v", err)
 					continue
 				}
 
 				if _, err := io.Copy(h, file); err != nil {
-					_ = file.Close() // #nosec G104 -- Error logged in checksum result, best effort close
+					_ = file.Close()
 					checksums[path] = fmt.Sprintf("error: %v", err)
 					continue
 				}
-				_ = file.Close() // #nosec G104 -- Best effort close after successful read
+				_ = file.Close()
 
 				checksums[path] = hex.EncodeToString(h.Sum(nil))
 			}
@@ -924,9 +924,9 @@ func (p *cryptoPack) verifyChecksumTool() tool.Tool {
 			var h hash.Hash
 			switch algorithm {
 			case "md5":
-				h = md5.New() // #nosec G401 -- MD5 is used for checksum/fingerprinting purposes, not for security
+				h = md5.New()
 			case "sha1":
-				h = sha1.New() // #nosec G401 -- SHA1 is used for checksum/fingerprinting purposes, not for security
+				h = sha1.New()
 			case "sha256":
 				h = sha256.New()
 			case "sha512":
@@ -935,7 +935,7 @@ func (p *cryptoPack) verifyChecksumTool() tool.Tool {
 				return tool.Result{}, fmt.Errorf("unsupported algorithm: %s", algorithm)
 			}
 
-			file, err := os.Open(params.Path) // #nosec G304 -- This is a checksum verification tool; path is provided by user input
+			file, err := os.Open(params.Path)
 			if err != nil {
 				return tool.Result{}, fmt.Errorf("failed to open file: %w", err)
 			}

--- a/contrib/pack-email/email.go
+++ b/contrib/pack-email/email.go
@@ -514,7 +514,7 @@ func (ep *emailPack) send(ctx context.Context, from string, to []string, msg []b
 	// STARTTLS
 	tlsCfg := &tls.Config{
 		ServerName:         ep.cfg.Host,
-		InsecureSkipVerify: ep.cfg.TLSInsecure, //nolint:gosec // Configurable for testing.
+		InsecureSkipVerify: ep.cfg.TLSInsecure,
 	}
 	if ok, _ := client.Extension("STARTTLS"); ok {
 		if err := client.StartTLS(tlsCfg); err != nil {

--- a/contrib/pack-fileops/fileops.go
+++ b/contrib/pack-fileops/fileops.go
@@ -22,7 +22,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
-	"crypto/md5" // #nosec G501 -- MD5 used for non-security checksum only
+	"crypto/md5"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
@@ -241,7 +241,6 @@ func fileopsRead(baseDir string) tool.Tool {
 				return tool.Result{}, err
 			}
 
-			// #nosec G304 -- path is sanitized via safePath
 			data, err := os.ReadFile(fullPath)
 			if err != nil {
 				return tool.Result{}, fmt.Errorf("failed to read file: %w", err)
@@ -307,7 +306,6 @@ func fileopsWrite(baseDir string) tool.Tool {
 			// Create backup if requested and file exists
 			if in.Backup && !created {
 				backupPath = fullPath + ".bak"
-				// #nosec G304 -- path is sanitized via safePath
 				existing, readErr := os.ReadFile(fullPath)
 				if readErr != nil {
 					return tool.Result{}, fmt.Errorf("failed to read file for backup: %w", readErr)
@@ -367,7 +365,6 @@ func fileopsAppend(baseDir string) tool.Tool {
 				return tool.Result{}, fmt.Errorf("failed to create directory: %w", err)
 			}
 
-			// #nosec G304 -- path is sanitized via safePath
 			f, err := os.OpenFile(fullPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 			if err != nil {
 				return tool.Result{}, fmt.Errorf("failed to open file: %w", err)
@@ -496,7 +493,6 @@ func fileopsSearch(baseDir string) tool.Tool {
 
 // searchFile searches a single file for regex matches.
 func searchFile(filePath string, re *regexp.Regexp, maxMatches int, baseDir string) ([]searchMatch, error) {
-	// #nosec G304 -- caller validates path via safePath
 	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
@@ -554,7 +550,6 @@ func fileopsReplace(baseDir string) tool.Tool {
 				return tool.Result{}, fmt.Errorf("invalid regex pattern: %w", err)
 			}
 
-			// #nosec G304 -- path is sanitized via safePath
 			data, err := os.ReadFile(fullPath)
 			if err != nil {
 				return tool.Result{}, fmt.Errorf("failed to read file: %w", err)
@@ -627,12 +622,10 @@ func fileopsDiff(baseDir string) tool.Tool {
 				return tool.Result{}, err
 			}
 
-			// #nosec G304 -- paths are sanitized via safePath
 			dataA, err := os.ReadFile(pathA)
 			if err != nil {
 				return tool.Result{}, fmt.Errorf("failed to read file A: %w", err)
 			}
-			// #nosec G304 -- paths are sanitized via safePath
 			dataB, err := os.ReadFile(pathB)
 			if err != nil {
 				return tool.Result{}, fmt.Errorf("failed to read file B: %w", err)
@@ -805,7 +798,6 @@ func createZipArchive(outputPath string, paths []string, baseDir string) (int, e
 				return createErr
 			}
 
-			// #nosec G304 -- path validated via safePath above
 			data, readErr := os.ReadFile(filePath)
 			if readErr != nil {
 				return readErr
@@ -861,7 +853,6 @@ func createTarArchive(outputPath string, paths []string, baseDir string, compres
 				return writeErr
 			}
 
-			// #nosec G304 -- path validated via safePath above
 			data, readErr := os.ReadFile(filePath)
 			if readErr != nil {
 				return readErr
@@ -986,7 +977,6 @@ func extractZip(archivePath, outputDir, baseDir string) (int, error) {
 }
 
 func extractTar(archivePath, outputDir, baseDir string, compressed bool) (int, error) {
-	// #nosec G304 -- path validated via safePath by caller
 	f, err := os.Open(archivePath)
 	if err != nil {
 		return 0, fmt.Errorf("failed to open archive: %w", err)
@@ -1076,7 +1066,7 @@ func fileopsChecksum(baseDir string) tool.Tool {
 			var h hash.Hash
 			switch algorithm {
 			case "md5":
-				h = md5.New() // #nosec G401 -- MD5 used for non-security checksum only
+				h = md5.New()
 			case "sha256":
 				h = sha256.New()
 			case "sha512":
@@ -1085,7 +1075,6 @@ func fileopsChecksum(baseDir string) tool.Tool {
 				return tool.Result{}, fmt.Errorf("unsupported algorithm: %s", algorithm)
 			}
 
-			// #nosec G304 -- path is sanitized via safePath
 			f, err := os.Open(fullPath)
 			if err != nil {
 				return tool.Result{}, fmt.Errorf("failed to open file: %w", err)

--- a/contrib/pack-grpc/grpc.go
+++ b/contrib/pack-grpc/grpc.go
@@ -94,7 +94,7 @@ func connectTool() tool.Tool {
 
 			pool.mu.Lock()
 			if existing, ok := pool.conns[id]; ok {
-				_ = existing.Close() // #nosec G104 -- best-effort close
+				_ = existing.Close()
 			}
 			pool.conns[id] = conn
 			pool.mu.Unlock()
@@ -125,7 +125,7 @@ func disconnectTool() tool.Tool {
 			pool.mu.Lock()
 			conn, ok := pool.conns[params.ID]
 			if ok {
-				_ = conn.Close() // #nosec G104 -- best-effort close
+				_ = conn.Close()
 				delete(pool.conns, params.ID)
 			}
 			pool.mu.Unlock()
@@ -206,7 +206,7 @@ func callTool() tool.Tool {
 			}
 
 			var response map[string]any
-			_ = json.Unmarshal(respBytes, &response) // #nosec G104 -- best-effort parse, empty response is acceptable
+			_ = json.Unmarshal(respBytes, &response)
 
 			result := map[string]any{
 				"id":       params.ID,
@@ -252,7 +252,7 @@ func closeAllTool() tool.Tool {
 			pool.mu.Lock()
 			count := len(pool.conns)
 			for id, conn := range pool.conns {
-				_ = conn.Close() // #nosec G104 -- best-effort close
+				_ = conn.Close()
 				delete(pool.conns, id)
 			}
 			pool.mu.Unlock()

--- a/contrib/pack-hash/hash.go
+++ b/contrib/pack-hash/hash.go
@@ -3,8 +3,8 @@ package hash
 
 import (
 	"context"
-	"crypto/md5"  // #nosec G501 -- MD5 provided for checksum/fingerprinting, not cryptographic security
-	"crypto/sha1" // #nosec G505 -- SHA1 provided for checksum/fingerprinting, not cryptographic security
+	"crypto/md5"
+	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/base64"
@@ -62,7 +62,7 @@ func md5Tool() tool.Tool {
 				data = params.Bytes
 			}
 
-			h := md5.Sum(data) // #nosec G401 -- MD5 provided for checksum/fingerprinting, not cryptographic security
+			h := md5.Sum(data)
 			hashHex := hex.EncodeToString(h[:])
 			hashB64 := base64.StdEncoding.EncodeToString(h[:])
 
@@ -96,7 +96,7 @@ func sha1Tool() tool.Tool {
 				data = params.Bytes
 			}
 
-			h := sha1.Sum(data) // #nosec G401 -- SHA1 provided for checksum/fingerprinting, not cryptographic security
+			h := sha1.Sum(data)
 			hashHex := hex.EncodeToString(h[:])
 			hashB64 := base64.StdEncoding.EncodeToString(h[:])
 
@@ -275,8 +275,8 @@ func multiTool() tool.Tool {
 
 			data := []byte(params.Text)
 
-			md5Sum := md5.Sum(data)   // #nosec G401 -- MD5 provided for checksum/fingerprinting, not cryptographic security
-			sha1Sum := sha1.Sum(data) // #nosec G401 -- SHA1 provided for checksum/fingerprinting, not cryptographic security
+			md5Sum := md5.Sum(data)
+			sha1Sum := sha1.Sum(data)
 			sha256Sum := sha256.Sum256(data)
 			sha512Sum := sha512.Sum512(data)
 			crc32Sum := crc32.ChecksumIEEE(data)
@@ -315,10 +315,10 @@ func verifyTool() tool.Tool {
 
 			switch strings.ToLower(params.Algorithm) {
 			case "md5":
-				h := md5.Sum(data) // #nosec G401 -- MD5 provided for checksum/fingerprinting, not cryptographic security
+				h := md5.Sum(data)
 				computed = hex.EncodeToString(h[:])
 			case "sha1":
-				h := sha1.Sum(data) // #nosec G401 -- SHA1 provided for checksum/fingerprinting, not cryptographic security
+				h := sha1.Sum(data)
 				computed = hex.EncodeToString(h[:])
 			case "sha256":
 				h := sha256.Sum256(data)

--- a/contrib/pack-jwt/jwt.go
+++ b/contrib/pack-jwt/jwt.go
@@ -264,7 +264,7 @@ func decodeTool() tool.Tool {
 				return tool.Result{}, err
 			}
 			var header map[string]any
-			_ = json.Unmarshal(headerJSON, &header) // #nosec G104 -- headerJSON already validated via base64 decode
+			_ = json.Unmarshal(headerJSON, &header)
 
 			// Decode payload
 			payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
@@ -272,7 +272,7 @@ func decodeTool() tool.Tool {
 				return tool.Result{}, err
 			}
 			var payload map[string]any
-			_ = json.Unmarshal(payloadJSON, &payload) // #nosec G104 -- payloadJSON already validated via base64 decode
+			_ = json.Unmarshal(payloadJSON, &payload)
 
 			result := map[string]any{
 				"header":    header,
@@ -307,7 +307,7 @@ func inspectTool() tool.Tool {
 			// Decode header
 			headerJSON, _ := base64.RawURLEncoding.DecodeString(parts[0])
 			var header map[string]any
-			_ = json.Unmarshal(headerJSON, &header) // #nosec G104 -- header parsing is best-effort for inspection
+			_ = json.Unmarshal(headerJSON, &header)
 
 			// Decode payload
 			payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])

--- a/contrib/pack-math/math.go
+++ b/contrib/pack-math/math.go
@@ -487,9 +487,9 @@ func randomTool() tool.Tool {
 			// Create random source
 			var rng *rand.Rand
 			if params.Seed != 0 {
-				rng = rand.New(rand.NewSource(params.Seed)) // #nosec G404 -- math/rand sufficient for general random
+				rng = rand.New(rand.NewSource(params.Seed))
 			} else {
-				rng = rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec G404 -- math/rand sufficient for general random
+				rng = rand.New(rand.NewSource(time.Now().UnixNano()))
 			}
 
 			values := make([]float64, count)

--- a/contrib/pack-process/process.go
+++ b/contrib/pack-process/process.go
@@ -229,7 +229,7 @@ func currentTool() tool.Tool {
 		ReadOnly().
 		Idempotent().
 		WithHandler(func(ctx context.Context, input json.RawMessage) (tool.Result, error) {
-			pid := int32(os.Getpid()) // #nosec G115 -- PID values are bounded by OS limits (max 2^22 on Linux)
+			pid := int32(os.Getpid())
 			p, err := process.NewProcessWithContext(ctx, pid)
 			if err != nil {
 				return tool.Result{}, err
@@ -279,7 +279,7 @@ func parentTool() tool.Tool {
 
 			pid := params.PID
 			if pid == 0 {
-				pid = int32(os.Getpid()) // #nosec G115 -- PID values are bounded by OS limits (max 2^22 on Linux)
+				pid = int32(os.Getpid())
 			}
 
 			p, err := process.NewProcessWithContext(ctx, pid)
@@ -322,7 +322,7 @@ func childrenTool() tool.Tool {
 
 			pid := params.PID
 			if pid == 0 {
-				pid = int32(os.Getpid()) // #nosec G115 -- PID values are bounded by OS limits (max 2^22 on Linux)
+				pid = int32(os.Getpid())
 			}
 
 			p, err := process.NewProcessWithContext(ctx, pid)
@@ -370,7 +370,7 @@ func memoryUsageTool() tool.Tool {
 
 			pid := params.PID
 			if pid == 0 {
-				pid = int32(os.Getpid()) // #nosec G115 -- PID values are bounded by OS limits (max 2^22 on Linux)
+				pid = int32(os.Getpid())
 			}
 
 			p, err := process.NewProcessWithContext(ctx, pid)
@@ -414,7 +414,7 @@ func cpuUsageTool() tool.Tool {
 
 			pid := params.PID
 			if pid == 0 {
-				pid = int32(os.Getpid()) // #nosec G115 -- PID values are bounded by OS limits (max 2^22 on Linux)
+				pid = int32(os.Getpid())
 			}
 
 			p, err := process.NewProcessWithContext(ctx, pid)
@@ -460,7 +460,7 @@ func connectionsTool() tool.Tool {
 
 			pid := params.PID
 			if pid == 0 {
-				pid = int32(os.Getpid()) // #nosec G115 -- PID values are bounded by OS limits (max 2^22 on Linux)
+				pid = int32(os.Getpid())
 			}
 
 			p, err := process.NewProcessWithContext(ctx, pid)
@@ -511,7 +511,7 @@ func openFilesTool() tool.Tool {
 
 			pid := params.PID
 			if pid == 0 {
-				pid = int32(os.Getpid()) // #nosec G115 -- PID values are bounded by OS limits (max 2^22 on Linux)
+				pid = int32(os.Getpid())
 			}
 
 			p, err := process.NewProcessWithContext(ctx, pid)

--- a/contrib/pack-retry/retry.go
+++ b/contrib/pack-retry/retry.go
@@ -556,7 +556,6 @@ func calculateDelay(baseDelay int, attempt int, multiplier float64, maxDelay int
 
 	if jitter > 0 {
 		jitterAmount := delay * jitter
-		// #nosec G404 -- math/rand is sufficient for jitter, no cryptographic security needed
 		delay += (rand.Float64()*2 - 1) * jitterAmount
 	}
 

--- a/contrib/pack-spreadsheet/spreadsheet.go
+++ b/contrib/pack-spreadsheet/spreadsheet.go
@@ -617,7 +617,7 @@ func (p *spreadsheetPack) writeExcelTool() tool.Tool {
 			if len(params.Headers) > 0 {
 				for col, header := range params.Headers {
 					cell, _ := excelize.CoordinatesToCellName(col+1, rowNum)
-					_ = f.SetCellValue(sheet, cell, header) // #nosec G104 -- best-effort write, errors handled at save
+					_ = f.SetCellValue(sheet, cell, header)
 				}
 				rowNum++
 			}
@@ -628,7 +628,7 @@ func (p *spreadsheetPack) writeExcelTool() tool.Tool {
 				case []interface{}:
 					for col, val := range v {
 						cell, _ := excelize.CoordinatesToCellName(col+1, rowNum)
-						_ = f.SetCellValue(sheet, cell, val) // #nosec G104 -- best-effort write, errors handled at save
+						_ = f.SetCellValue(sheet, cell, val)
 					}
 				case map[string]interface{}:
 					if len(params.Headers) == 0 {
@@ -637,14 +637,14 @@ func (p *spreadsheetPack) writeExcelTool() tool.Tool {
 						}
 						for col, header := range params.Headers {
 							cell, _ := excelize.CoordinatesToCellName(col+1, 1)
-							_ = f.SetCellValue(sheet, cell, header) // #nosec G104 -- best-effort write, errors handled at save
+							_ = f.SetCellValue(sheet, cell, header)
 						}
 						rowNum = 2
 					}
 					for col, h := range params.Headers {
 						if val, ok := v[h]; ok {
 							cell, _ := excelize.CoordinatesToCellName(col+1, rowNum)
-							_ = f.SetCellValue(sheet, cell, val) // #nosec G104 -- best-effort write, errors handled at save
+							_ = f.SetCellValue(sheet, cell, val)
 						}
 					}
 				}

--- a/contrib/pack-sql/sql.go
+++ b/contrib/pack-sql/sql.go
@@ -657,7 +657,7 @@ func (p *sqlPack) insertTool() tool.Tool {
 			}
 
 			// Table and column names are validated above; placeholders use parameterized values
-			query := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", // #nosec G201 -- identifiers validated
+			query := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
 				p.quoteIdentifier(in.Table),
 				strings.Join(columns, ", "),
 				strings.Join(placeholders, ", "))
@@ -732,7 +732,7 @@ func (p *sqlPack) updateTool() tool.Tool {
 			values = append(values, in.Params...)
 
 			// Table and column names validated; WHERE uses parameterized values via in.Params
-			query := fmt.Sprintf("UPDATE %s SET %s WHERE %s", // #nosec G201 -- identifiers validated, WHERE uses params
+			query := fmt.Sprintf("UPDATE %s SET %s WHERE %s",
 				p.quoteIdentifier(in.Table),
 				strings.Join(setClauses, ", "),
 				in.Where)
@@ -782,7 +782,7 @@ func (p *sqlPack) deleteTool() tool.Tool {
 			}
 
 			// Table name validated; WHERE uses parameterized values via in.Params
-			query := fmt.Sprintf("DELETE FROM %s WHERE %s", p.quoteIdentifier(in.Table), in.Where) // #nosec G201 -- table validated, WHERE uses params
+			query := fmt.Sprintf("DELETE FROM %s WHERE %s", p.quoteIdentifier(in.Table), in.Where)
 
 			result, err := db.ExecContext(ctx, query, in.Params...)
 			if err != nil {
@@ -826,7 +826,7 @@ func (p *sqlPack) countTool() tool.Tool {
 			}
 
 			// Table name validated; WHERE uses parameterized values via in.Params
-			query := fmt.Sprintf("SELECT COUNT(*) FROM %s", p.quoteIdentifier(in.Table)) // #nosec G201 -- table validated
+			query := fmt.Sprintf("SELECT COUNT(*) FROM %s", p.quoteIdentifier(in.Table))
 			if in.Where != "" {
 				query += " WHERE " + in.Where
 			}
@@ -876,7 +876,7 @@ func (p *sqlPack) transactionTool() tool.Tool {
 			for i, stmt := range in.Statements {
 				result, err := tx.ExecContext(ctx, stmt.Query, stmt.Params...)
 				if err != nil {
-					_ = tx.Rollback() // #nosec G104 -- best-effort rollback, original error takes precedence
+					_ = tx.Rollback()
 					return tool.Result{}, fmt.Errorf("statement %d failed: %w", i, err)
 				}
 

--- a/contrib/pack-ssh/ssh.go
+++ b/contrib/pack-ssh/ssh.go
@@ -108,7 +108,7 @@ func connectTool() tool.Tool {
 						home, _ := os.UserHomeDir()
 						keyPath = filepath.Join(home, keyPath[1:])
 					}
-					keyData, err = os.ReadFile(keyPath) // #nosec G304 -- intentional file read for SSH key tool
+					keyData, err = os.ReadFile(keyPath)
 					if err != nil {
 						return tool.Result{}, err
 					}
@@ -134,7 +134,6 @@ func connectTool() tool.Tool {
 					return tool.Result{}, fmt.Errorf("failed to load known_hosts: %w", khErr)
 				}
 			} else {
-				// #nosec G106 -- InsecureIgnoreHostKey used when no known_hosts_file is provided; callers should supply known_hosts_file in production
 				hostKeyCallback = ssh.InsecureIgnoreHostKey()
 			}
 
@@ -153,7 +152,7 @@ func connectTool() tool.Tool {
 
 			pool.mu.Lock()
 			if existing, ok := pool.conns[id]; ok {
-				_ = existing.Close() // #nosec G104 -- best-effort close of existing connection
+				_ = existing.Close()
 			}
 			pool.conns[id] = client
 			pool.mu.Unlock()
@@ -185,7 +184,7 @@ func disconnectTool() tool.Tool {
 			pool.mu.Lock()
 			client, ok := pool.conns[params.ID]
 			if ok {
-				_ = client.Close() // #nosec G104 -- best-effort close
+				_ = client.Close()
 				delete(pool.conns, params.ID)
 			}
 			pool.mu.Unlock()
@@ -313,7 +312,7 @@ func shellTool() tool.Tool {
 					"exit_code": exitCode,
 				})
 
-				_ = session.Close() // #nosec G104 -- best-effort close
+				_ = session.Close()
 			}
 
 			result := map[string]any{
@@ -375,9 +374,9 @@ func scpUploadTool() tool.Tool {
 			// SCP protocol
 			go func() {
 				w, _ := session.StdinPipe()
-				defer func() { _ = w.Close() }() // #nosec G104 -- best-effort close
+				defer func() { _ = w.Close() }()
 				fmt.Fprintf(w, "C0644 %d %s\n", len(data), filepath.Base(params.RemotePath))
-				_, _ = w.Write(data) // #nosec G104 -- write error handled by session.Run
+				_, _ = w.Write(data)
 				fmt.Fprint(w, "\x00")
 			}()
 
@@ -442,7 +441,7 @@ func scpDownloadTool() tool.Tool {
 			content := stdout.Bytes()
 
 			if params.LocalPath != "" {
-				err = os.WriteFile(params.LocalPath, content, 0600) // #nosec G306 -- restrictive permissions for downloaded files
+				err = os.WriteFile(params.LocalPath, content, 0600)
 				if err != nil {
 					return tool.Result{}, err
 				}
@@ -508,7 +507,7 @@ func tunnelTool() tool.Tool {
 
 					remote, err := client.Dial("tcp", remoteAddr)
 					if err != nil {
-						_ = local.Close() // #nosec G104 -- best-effort close on dial failure
+						_ = local.Close()
 						continue
 					}
 
@@ -524,7 +523,7 @@ func tunnelTool() tool.Tool {
 								if err != nil {
 									return
 								}
-								_, _ = remote.Write(buf[:n]) // #nosec G104 -- best-effort tunnel write
+								_, _ = remote.Write(buf[:n])
 							}
 						}()
 
@@ -534,7 +533,7 @@ func tunnelTool() tool.Tool {
 							if err != nil {
 								return
 							}
-							_, _ = local.Write(buf[:n]) // #nosec G104 -- best-effort tunnel write
+							_, _ = local.Write(buf[:n])
 						}
 					}()
 				}
@@ -583,7 +582,7 @@ func closeAllTool() tool.Tool {
 			pool.mu.Lock()
 			count := len(pool.conns)
 			for id, client := range pool.conns {
-				_ = client.Close() // #nosec G104 -- best-effort close
+				_ = client.Close()
 				delete(pool.conns, id)
 			}
 			pool.mu.Unlock()
@@ -691,7 +690,6 @@ func hostKeyTool() tool.Tool {
 
 			var hostKey ssh.PublicKey
 			config := &ssh.ClientConfig{
-				// #nosec G106 -- intentional to capture host key before verification
 				HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 					hostKey = key
 					return nil
@@ -702,7 +700,7 @@ func hostKeyTool() tool.Tool {
 			addr := fmt.Sprintf("%s:%d", params.Host, port)
 			conn, err := ssh.Dial("tcp", addr, config)
 			if conn != nil {
-				_ = conn.Close() // #nosec G104 -- best-effort close
+				_ = conn.Close()
 			}
 
 			// We expect an error (no auth), but we captured the host key

--- a/contrib/pack-string/string.go
+++ b/contrib/pack-string/string.go
@@ -3,8 +3,8 @@ package stringutil
 
 import (
 	"context"
-	"crypto/md5"  // #nosec G501 -- MD5 used for checksums/fingerprinting, not cryptographic security
-	"crypto/sha1" // #nosec G505 -- SHA1 used for checksums/fingerprinting, not cryptographic security
+	"crypto/md5"
+	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -578,11 +578,11 @@ func hashTool() tool.Tool {
 
 			switch strings.ToLower(algorithm) {
 			case "md5":
-				hash := md5.Sum(data) // #nosec G401 -- MD5 used for checksums/fingerprinting, not cryptographic security
+				hash := md5.Sum(data)
 				hashHex = hex.EncodeToString(hash[:])
 				algorithm = "md5"
 			case "sha1":
-				hash := sha1.Sum(data) // #nosec G401 -- SHA1 used for checksums/fingerprinting, not cryptographic security
+				hash := sha1.Sum(data)
 				hashHex = hex.EncodeToString(hash[:])
 				algorithm = "sha1"
 			default:

--- a/contrib/pack-validate/validate.go
+++ b/contrib/pack-validate/validate.go
@@ -213,7 +213,7 @@ func uuidTool() tool.Tool {
 			if valid {
 				// Extract version from position 14 (single hex digit, always 0-15)
 				v, _ := strconv.ParseUint(string(params.UUID[14]), 16, 8)
-				version = int(v) // #nosec G115 -- value is a single hex digit (0-15)
+				version = int(v)
 
 				if params.Version != 0 && params.Version != version {
 					valid = false

--- a/contrib/pack-websocket/websocket.go
+++ b/contrib/pack-websocket/websocket.go
@@ -85,7 +85,7 @@ func connectTool() tool.Tool {
 
 			pool.mu.Lock()
 			if existing, ok := pool.conns[id]; ok {
-				_ = existing.Close() // #nosec G104 -- best-effort close
+				_ = existing.Close()
 			}
 			pool.conns[id] = conn
 			pool.mu.Unlock()
@@ -116,8 +116,8 @@ func disconnectTool() tool.Tool {
 			pool.mu.Lock()
 			conn, ok := pool.conns[params.ID]
 			if ok {
-				_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")) // #nosec G104 -- best-effort close message
-				_ = conn.Close()                                                                                              // #nosec G104 -- best-effort close
+				_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+				_ = conn.Close()
 				delete(pool.conns, params.ID)
 			}
 			pool.mu.Unlock()
@@ -203,9 +203,9 @@ func receiveTool() tool.Tool {
 				timeout = 30 * time.Second
 			}
 
-			_ = conn.SetReadDeadline(time.Now().Add(timeout)) // #nosec G104 -- best-effort deadline
+			_ = conn.SetReadDeadline(time.Now().Add(timeout))
 			messageType, message, err := conn.ReadMessage()
-			_ = conn.SetReadDeadline(time.Time{}) // #nosec G104 -- best-effort deadline clear
+			_ = conn.SetReadDeadline(time.Time{})
 
 			if err != nil {
 				return tool.Result{}, err
@@ -301,10 +301,10 @@ func receiveJSONTool() tool.Tool {
 				timeout = 30 * time.Second
 			}
 
-			_ = conn.SetReadDeadline(time.Now().Add(timeout)) // #nosec G104 -- best-effort deadline
+			_ = conn.SetReadDeadline(time.Now().Add(timeout))
 			var data map[string]any
 			err := conn.ReadJSON(&data)
-			_ = conn.SetReadDeadline(time.Time{}) // #nosec G104 -- best-effort deadline clear
+			_ = conn.SetReadDeadline(time.Time{})
 
 			if err != nil {
 				return tool.Result{}, err
@@ -415,8 +415,8 @@ func closeAllTool() tool.Tool {
 			pool.mu.Lock()
 			count := len(pool.conns)
 			for id, conn := range pool.conns {
-				_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")) // #nosec G104 -- best-effort close message
-				_ = conn.Close()                                                                                              // #nosec G104 -- best-effort close
+				_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+				_ = conn.Close()
 				delete(pool.conns, id)
 			}
 			pool.mu.Unlock()
@@ -470,9 +470,9 @@ func sendReceiveTool() tool.Tool {
 			}
 
 			// Receive
-			_ = conn.SetReadDeadline(time.Now().Add(timeout)) // #nosec G104 -- best-effort deadline
+			_ = conn.SetReadDeadline(time.Now().Add(timeout))
 			_, response, err := conn.ReadMessage()
-			_ = conn.SetReadDeadline(time.Time{}) // #nosec G104 -- best-effort deadline clear
+			_ = conn.SetReadDeadline(time.Time{})
 
 			if err != nil {
 				return tool.Result{}, err

--- a/contrib/pack-yaml/yaml.go
+++ b/contrib/pack-yaml/yaml.go
@@ -145,12 +145,12 @@ func (p *yamlPack) stringifyTool() tool.Tool {
 			if err := encoder.Encode(params.Data); err != nil {
 				return tool.Result{}, fmt.Errorf("failed to encode YAML: %w", err)
 			}
-			_ = encoder.Close() // #nosec G104 -- best-effort close
+			_ = encoder.Close()
 
 			result := map[string]interface{}{
 				"yaml": buf.String(),
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- marshaling simple map
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -185,7 +185,7 @@ func (p *yamlPack) writeFileTool() tool.Tool {
 			if err := encoder.Encode(params.Data); err != nil {
 				return tool.Result{}, fmt.Errorf("failed to encode YAML: %w", err)
 			}
-			_ = encoder.Close() // #nosec G104 -- best-effort close
+			_ = encoder.Close()
 
 			if err := os.WriteFile(params.Path, buf.Bytes(), 0600); err != nil {
 				return tool.Result{}, fmt.Errorf("failed to write file: %w", err)
@@ -279,12 +279,12 @@ func (p *yamlPack) fromJSONTool() tool.Tool {
 			if err := encoder.Encode(data); err != nil {
 				return tool.Result{}, fmt.Errorf("failed to encode YAML: %w", err)
 			}
-			_ = encoder.Close() // #nosec G104 -- best-effort close
+			_ = encoder.Close()
 
 			result := map[string]interface{}{
 				"yaml": buf.String(),
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- marshaling simple map
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -334,7 +334,7 @@ func (p *yamlPack) mergeTool() tool.Tool {
 			if err := encoder.Encode(result); err != nil {
 				return tool.Result{}, fmt.Errorf("failed to encode YAML: %w", err)
 			}
-			_ = encoder.Close() // #nosec G104 -- best-effort close
+			_ = encoder.Close()
 
 			output, _ := json.Marshal(map[string]interface{}{
 				"yaml":   buf.String(),
@@ -470,14 +470,14 @@ func (p *yamlPack) setTool() tool.Tool {
 			if err := encoder.Encode(dataMap); err != nil {
 				return tool.Result{}, fmt.Errorf("failed to encode YAML: %w", err)
 			}
-			_ = encoder.Close() // #nosec G104 -- best-effort close
+			_ = encoder.Close()
 
 			result := map[string]interface{}{
 				"yaml":    buf.String(),
 				"path":    params.Path,
 				"success": true,
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- marshaling simple map
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -537,14 +537,14 @@ func (p *yamlPack) deleteTool() tool.Tool {
 			if err := encoder.Encode(dataMap); err != nil {
 				return tool.Result{}, fmt.Errorf("failed to encode YAML: %w", err)
 			}
-			_ = encoder.Close() // #nosec G104 -- best-effort close
+			_ = encoder.Close()
 
 			result := map[string]interface{}{
 				"yaml":    buf.String(),
 				"deleted": true,
 				"path":    params.Path,
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- marshaling simple map
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()
@@ -664,13 +664,13 @@ func (p *yamlPack) multiDocStringifyTool() tool.Tool {
 					return tool.Result{}, fmt.Errorf("failed to encode document: %w", err)
 				}
 			}
-			_ = encoder.Close() // #nosec G104 -- best-effort close
+			_ = encoder.Close()
 
 			result := map[string]interface{}{
 				"yaml":  buf.String(),
 				"count": len(params.Documents),
 			}
-			output, _ := json.Marshal(result) // #nosec G104 -- marshaling simple map
+			output, _ := json.Marshal(result)
 			return tool.Result{Output: output}, nil
 		}).
 		MustBuild()

--- a/example/02-tools/main.go
+++ b/example/02-tools/main.go
@@ -30,7 +30,7 @@ func run() error {
 
 	// Create test file
 	testFile := filepath.Join(tmpDir, "test.txt")
-	_ = os.WriteFile(testFile, []byte("Hello from the test file!"), 0600) // #nosec G306
+	_ = os.WriteFile(testFile, []byte("Hello from the test file!"), 0600)
 
 	// ============================================
 	// Tool 1: read_file (ReadOnly, Idempotent, Cacheable)
@@ -84,7 +84,7 @@ func run() error {
 				return tool.Result{}, err
 			}
 
-			if err := os.WriteFile(in.Path, []byte(in.Content), 0600); err != nil { // #nosec G306
+			if err := os.WriteFile(in.Path, []byte(in.Content), 0600); err != nil {
 				return tool.Result{}, fmt.Errorf("failed to write file: %w", err)
 			}
 
@@ -208,7 +208,6 @@ func run() error {
 	fmt.Println()
 
 	// Verify output was written
-	// #nosec G304 -- example code reading known output file in controlled temp directory
 	if content, err := os.ReadFile(outputFile); err == nil {
 		fmt.Printf("Output file contents: %s\n", string(content))
 	}

--- a/example/fileops/main.go
+++ b/example/fileops/main.go
@@ -200,7 +200,6 @@ func runExample(workDir string) error {
 
 	// Verify the file was actually created
 	filePath := filepath.Join(workDir, "hello.txt")
-	// #nosec G304 -- example code reading known file in controlled temp directory
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("file verification failed: %w", err)

--- a/example/fileops/tools.go
+++ b/example/fileops/tools.go
@@ -99,7 +99,6 @@ func NewReadFileTool(baseDir string) tool.Tool {
 				return tool.Result{}, fmt.Errorf("path traversal attempt: %s", in.Path)
 			}
 
-			// #nosec G304 -- path is sanitized above with filepath.Clean and isSubPath check
 			content, err := os.ReadFile(fullPath)
 			if err != nil {
 				return tool.Result{}, fmt.Errorf("failed to read file: %w", err)

--- a/example/governed_adaptivity/main.go
+++ b/example/governed_adaptivity/main.go
@@ -390,8 +390,8 @@ func exportVisualization(ctx context.Context, runStore *memory.RunStore, eventSt
 		fmt.Println("  ```")
 
 		// Save exports to files (example code - permissive for readability)
-		_ = os.WriteFile("state_machine.dot", dotData, 0600)     // #nosec G306
-		_ = os.WriteFile("state_machine.mmd", mermaidData, 0600) // #nosec G306
+		_ = os.WriteFile("state_machine.dot", dotData, 0600)
+		_ = os.WriteFile("state_machine.mmd", mermaidData, 0600)
 		fmt.Println("\n  Saved: state_machine.dot, state_machine.mmd")
 	}
 

--- a/infrastructure/config/loader.go
+++ b/infrastructure/config/loader.go
@@ -84,7 +84,7 @@ func (l *Loader) LoadFile(path string) (*config.AgentConfig, error) {
 	}
 
 	// Open file with cleaned path
-	f, err := os.Open(cleanPath) // #nosec G304 - path is cleaned above
+	f, err := os.Open(cleanPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open config file: %w", err)
 	}

--- a/infrastructure/inspector/html_formatter.go
+++ b/infrastructure/inspector/html_formatter.go
@@ -61,7 +61,7 @@ func (f *HTMLFormatter) Format(data any) ([]byte, error) {
 	err = tmpl.Execute(&buf, map[string]any{
 		"Title": f.title,
 		"Theme": f.theme,
-		"Data":  template.JS(jsonData), // #nosec G203 -- Data is marshaled JSON, safe for embedding
+		"Data":  template.JS(jsonData),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute template: %w", err)

--- a/infrastructure/notification/sender.go
+++ b/infrastructure/notification/sender.go
@@ -195,7 +195,7 @@ func (s *Sender) getBreaker(url string) circuitbreaker.CircuitBreaker[*http.Resp
 		Interval:    s.config.CircuitBreakerTimeout,
 		Timeout:     s.config.CircuitBreakerTimeout,
 		ReadyToTrip: func(counts circuitbreaker.Counts) bool {
-			return counts.ConsecutiveFailures >= uint32(threshold) // #nosec G115 -- threshold is validated
+			return counts.ConsecutiveFailures >= uint32(threshold)
 		},
 	})
 	s.breakers[url] = breaker

--- a/infrastructure/resilience/backoff.go
+++ b/infrastructure/resilience/backoff.go
@@ -194,7 +194,7 @@ func (b *JitteredBackoff) Next(attempt int) (time.Duration, bool) {
 	}
 
 	// Backoff jitter is not security-sensitive; a weak PRNG is appropriate.
-	jitter := time.Duration(rand.Float64() * factor * float64(delay)) //nolint:gosec // G404: jitter does not require crypto-strength randomness
+	jitter := time.Duration(rand.Float64() * factor * float64(delay))
 	return delay + jitter, true
 }
 

--- a/infrastructure/resilience/executor.go
+++ b/infrastructure/resilience/executor.go
@@ -126,11 +126,11 @@ func NewExecutor(config ExecutorConfig) *Executor {
 			MaxConcurrent: maxConcurrent,
 		}),
 		breaker: circuitbreaker.New[tool.Result](circuitbreaker.Config{
-			MaxRequests: uint32(maxConcurrent), // #nosec G115 -- bounds checked above
+			MaxRequests: uint32(maxConcurrent),
 			Interval:    config.CircuitBreakerTimeout,
 			Timeout:     config.CircuitBreakerTimeout,
 			ReadyToTrip: func(counts circuitbreaker.Counts) bool {
-				return counts.ConsecutiveFailures >= uint32(threshold) // #nosec G115 -- bounds checked above
+				return counts.ConsecutiveFailures >= uint32(threshold)
 			},
 		}),
 		retry: retry.New[tool.Result](retry.Config{

--- a/infrastructure/storage/filesystem/artifact_store.go
+++ b/infrastructure/storage/filesystem/artifact_store.go
@@ -43,7 +43,6 @@ func (s *ArtifactStore) Store(ctx context.Context, content io.Reader, opts artif
 
 	// Write content to file
 	contentPath := filepath.Join(artifactPath, "content")
-	// #nosec G304 -- path is constructed from internally generated artifact ID, not user input
 	file, err := os.Create(contentPath)
 	if err != nil {
 		return artifact.Ref{}, fmt.Errorf("failed to create content file: %w", err)
@@ -55,14 +54,14 @@ func (s *ArtifactStore) Store(ctx context.Context, content io.Reader, opts artif
 
 	size, err := io.Copy(writer, content)
 	if err != nil {
-		file.Close()               // #nosec G104 -- best-effort cleanup in error path
-		os.RemoveAll(artifactPath) // #nosec G104 -- best-effort cleanup in error path
+		file.Close()
+		os.RemoveAll(artifactPath)
 		return artifact.Ref{}, fmt.Errorf("failed to write content: %w", err)
 	}
 
 	// Close content file and check for write errors (G104 fix)
 	if err := file.Close(); err != nil {
-		os.RemoveAll(artifactPath) // #nosec G104 -- best-effort cleanup in error path
+		os.RemoveAll(artifactPath)
 		return artifact.Ref{}, fmt.Errorf("failed to close content file: %w", err)
 	}
 
@@ -87,22 +86,21 @@ func (s *ArtifactStore) Store(ctx context.Context, content io.Reader, opts artif
 
 	// Write metadata file
 	metaPath := filepath.Join(artifactPath, "metadata.json")
-	// #nosec G304 -- path is constructed from internally generated artifact ID, not user input
 	metaFile, err := os.Create(metaPath)
 	if err != nil {
-		os.RemoveAll(artifactPath) // #nosec G104 -- best-effort cleanup in error path
+		os.RemoveAll(artifactPath)
 		return artifact.Ref{}, fmt.Errorf("failed to create metadata file: %w", err)
 	}
 
 	if err := json.NewEncoder(metaFile).Encode(ref); err != nil {
-		metaFile.Close()           // #nosec G104 -- best-effort cleanup in error path
-		os.RemoveAll(artifactPath) // #nosec G104 -- best-effort cleanup in error path
+		metaFile.Close()
+		os.RemoveAll(artifactPath)
 		return artifact.Ref{}, fmt.Errorf("failed to write metadata: %w", err)
 	}
 
 	// Close metadata file and check for write errors (G104 fix)
 	if err := metaFile.Close(); err != nil {
-		os.RemoveAll(artifactPath) // #nosec G104 -- best-effort cleanup in error path
+		os.RemoveAll(artifactPath)
 		return artifact.Ref{}, fmt.Errorf("failed to close metadata file: %w", err)
 	}
 
@@ -116,7 +114,6 @@ func (s *ArtifactStore) Retrieve(_ context.Context, ref artifact.Ref) (io.ReadCl
 	}
 
 	contentPath := filepath.Join(s.artifactPath(ref.ID), "content")
-	// #nosec G304 -- path is constructed from validated artifact ref, not user input
 	file, err := os.Open(contentPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -170,7 +167,6 @@ func (s *ArtifactStore) Metadata(_ context.Context, ref artifact.Ref) (artifact.
 	}
 
 	metaPath := filepath.Join(s.artifactPath(ref.ID), "metadata.json")
-	// #nosec G304 -- path is constructed from validated artifact ref, not user input
 	file, err := os.Open(metaPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -178,7 +174,7 @@ func (s *ArtifactStore) Metadata(_ context.Context, ref artifact.Ref) (artifact.
 		}
 		return artifact.Ref{}, fmt.Errorf("failed to open metadata: %w", err)
 	}
-	defer file.Close() // #nosec G104 -- read-only operation, close error is non-critical
+	defer file.Close()
 
 	var storedRef artifact.Ref
 	if err := json.NewDecoder(file).Decode(&storedRef); err != nil {


### PR DESCRIPTION
## Drop gosec — security is owned by nox

The org has standardized on **nox** for security scanning (secrets + IaC + dependency + AI + taint-analysis SAST), replacing gosec at the code-lint layer. The golden config in `klarlabs-studio/.github` (`golangci.reference.yml`) already dropped gosec; this PR brings `agent-go` in line.

### Changes
- **`.golangci.yml`**: removed `gosec` from `linters.enable`, removed the `linters.settings.gosec` block (where present), and pruned gosec from `exclusions.rules` (dropping gosec-only rules entirely, removing the `gosec` token from mixed rules). Everything else — gocritic, the standard set, formatters, repo-specific config — is preserved unchanged.
- **Dead suppressions**: removed 216 now-unused gosec lint directives (`//nolint:gosec` / `// #nosec Gxxx`) that become dead once gosec is gone. For mixed `//nolint:errcheck,gosec` directives, only the `gosec` token was removed; the rest is kept.

### Verification
- `.golangci.yml` parses; no residual gosec references.
- `golangci-lint run ./...` (v2.12.2, the CI-pinned version) and `go build ./...` run locally.
- Removing gosec + its suppressions can only reduce lint findings.

No merge intended — opening for the Lint CI gate to confirm green.