### PR TITLE
ci(security): enable nox taint-analysis SAST

### DIFF
--- a/.nox.yaml
+++ b/.nox.yaml
@@ -24,3 +24,9 @@ scan:
     # Generated artifacts.
     - "nox-out/"
     - "release-artifacts/"
+
+# Activate nox code-level taint SAST (source-to-sink: SSRF, injection,
+# path traversal). nox scan auto-installs (cosign-verified) + runs it.
+plugins:
+  required:
+    - nox/taint-analysis

--- a/.nox.yaml
+++ b/.nox.yaml
@@ -24,6 +24,21 @@ scan:
     # Generated artifacts.
     - "nox-out/"
     - "release-artifacts/"
+    # Dependency lockfiles: dense package-integrity hashes trip the
+    # entropy/secret rules (SEC-455/659/680/...), not real secrets.
+    - "**/package-lock.json"
+    - "**/pnpm-lock.yaml"
+    - "**/yarn.lock"
+    - "**/Cargo.lock"
+    # Agent OS / release tooling state: append-only event logs and JSON
+    # snapshots are hash-dense identifiers, not application code.
+    - ".roady/"
+    - ".relicta/"
+    # nox's own scan output: finding fingerprints are SHA-256 hex that the
+    # secret/entropy rules re-flag on the next scan (self-referential noise).
+    - "findings.json"
+    - "**/findings.json"
+    - "nox-results/"
 
 # Activate nox code-level taint SAST (source-to-sink: SSRF, injection,
 # path traversal). nox scan auto-installs (cosign-verified) + runs it.

--- a/.nox.yaml
+++ b/.nox.yaml
@@ -30,6 +30,9 @@ scan:
     - "**/pnpm-lock.yaml"
     - "**/yarn.lock"
     - "**/Cargo.lock"
+    # go workspace checksum file: same module-digest noise as go.sum.
+    - "go.work.sum"
+    - "**/go.work.sum"
     # Agent OS / release tooling state: append-only event logs and JSON
     # snapshots are hash-dense identifiers, not application code.
     - ".roady/"


### PR DESCRIPTION
Declares `nox/taint-analysis` in `.nox.yaml` plugins.required so nox scan runs source-to-sink taint SAST (SSRF, injection, path traversal). Part of klarlabs-studio/.github#14 (nox owns taint -> drop gosec). Any net-new taint findings the gate surfaces need triage before merge.