### PR TITLE
fix(planner-llm): make module standalone-releasable

### DIFF
--- a/contrib/planner-llm/go.mod
+++ b/contrib/planner-llm/go.mod
@@ -2,6 +2,4 @@ module go.klarlabs.de/agent/contrib/planner-llm
 
 go 1.25.0
 
-require go.klarlabs.de/agent v0.6.0
-
-replace go.klarlabs.de/agent => ../..
+require go.klarlabs.de/agent v0.10.0

--- a/contrib/planner-llm/go.sum
+++ b/contrib/planner-llm/go.sum
@@ -1,0 +1,2 @@
+go.klarlabs.de/agent v0.10.0 h1:eCWFU38N6Cyji8GXmA32+llx3QZ40GGKd9rdrXezf6k=
+go.klarlabs.de/agent v0.10.0/go.mod h1:3b4RsqGRjJXhuMh74k0Y8sNUtgC1vaZFf0q0MT2bp0Q=


### PR DESCRIPTION
planner-llm shipped a local `replace go.klarlabs.de/agent => ../..` and required the base at **v0.6.0** (old module path; the rename to `go.klarlabs.de/agent` lands at **v0.10.0**). The published module was therefore unresolvable standalone, blocking the nox AI plugins (grc, red-team, triage-agent) that import it.

Drop the replace, require published `go.klarlabs.de/agent v0.10.0`, add go.sum. Builds + tests pass standalone. After merge, tag `contrib/planner-llm/v0.3.0` so the plugins can pin it.