### PR TITLE
feat: full budget+evidence delegation to axi (run-as-one-session)

### DIFF
--- a/application/engine.go
+++ b/application/engine.go
@@ -227,7 +227,7 @@ func (e *Engine) executeRun(ctx context.Context, runID, goal string, vars map[st
 	machineCtx := statemachine.NewContext(r, budget, runLedger)
 	machineCtx.Eligibility = e.eligibility
 	machineCtx.Transitions = e.transitions
-	machineCtx.Governor = e.govFactory.Governor(budget)
+	machineCtx.Governor = e.govFactory.Governor(ctx, budget)
 	// Some Governors (full axi delegation) hold a per-run axi session that
 	// must be released when the run ends. Close it on every exit path.
 	defer closeGovernor(machineCtx.Governor)
@@ -442,7 +442,7 @@ func (e *Engine) ResumeWithInput(ctx context.Context, run *agent.Run, input stri
 	machineCtx := statemachine.NewContext(run, budget, runLedger)
 	machineCtx.Eligibility = e.eligibility
 	machineCtx.Transitions = e.transitions
-	machineCtx.Governor = e.govFactory.Governor(budget)
+	machineCtx.Governor = e.govFactory.Governor(ctx, budget)
 	defer closeGovernor(machineCtx.Governor)
 
 	// Create state machine

--- a/application/engine.go
+++ b/application/engine.go
@@ -68,9 +68,10 @@ type EngineConfig struct {
 	RunStore     run.Store
 	EventStore   event.Store
 	TaskContext  *task.Context
-	// Governance selects the governance backend (budget + approval). When
-	// nil, an axi-backed factory is used: the destructive-tool approval gate
-	// is delegated to an axi.Kernel.
+	// Governance selects the governance backend (budget + approval +
+	// evidence). When nil, the full-delegation KernelFactory is used: each run
+	// is ONE axi session, so budget, the destructive-tool approval gate, and
+	// the evidence chain are all axi-native.
 	Governance governance.Factory
 }
 
@@ -117,10 +118,14 @@ func NewEngine(config EngineConfig) (*Engine, error) {
 		e.maxSteps = 100
 	}
 	if e.govFactory == nil {
-		// Default governance: delegate the destructive-tool approval gate to
-		// an axi.Kernel (spec § Changes Required #1). Budget stays run-level
-		// in agent-go; see infrastructure/governance.
-		f, err := governance.NewAxiFactory(e.approver)
+		// Default governance: FULL axi delegation (spec § Changes Required #1,
+		// Track F). Each run executes as ONE axi session, so budget, the
+		// destructive-tool approval gate, AND the tamper-evident evidence chain
+		// are all axi-native — the only tier that satisfies the spec
+		// non-negotiable "budget AND approval always through axi". AxiFactory
+		// (approval-only) and PassthroughFactory remain selectable via
+		// api.WithGovernance. See infrastructure/governance.
+		f, err := governance.NewKernelFactory(e.approver)
 		if err != nil {
 			return nil, fmt.Errorf("init governance: %w", err)
 		}

--- a/application/engine.go
+++ b/application/engine.go
@@ -228,6 +228,9 @@ func (e *Engine) executeRun(ctx context.Context, runID, goal string, vars map[st
 	machineCtx.Eligibility = e.eligibility
 	machineCtx.Transitions = e.transitions
 	machineCtx.Governor = e.govFactory.Governor(budget)
+	// Some Governors (full axi delegation) hold a per-run axi session that
+	// must be released when the run ends. Close it on every exit path.
+	defer closeGovernor(machineCtx.Governor)
 
 	// Create state machine
 	machine, err := statemachine.NewAgentMachine()
@@ -424,6 +427,7 @@ func (e *Engine) ResumeWithInput(ctx context.Context, run *agent.Run, input stri
 	machineCtx.Eligibility = e.eligibility
 	machineCtx.Transitions = e.transitions
 	machineCtx.Governor = e.govFactory.Governor(budget)
+	defer closeGovernor(machineCtx.Governor)
 
 	// Create state machine
 	machine, err := statemachine.NewAgentMachine()
@@ -827,6 +831,20 @@ func (e *Engine) publishEvent(ctx context.Context, runID string, eventType event
 	}
 	if err := e.eventStore.Append(ctx, evt); err != nil {
 		logging.Error().Add(logging.RunID(runID)).Add(logging.ErrorField(err)).Msg("failed to publish event")
+	}
+}
+
+// closeGovernor releases a per-run Governor that holds resources (e.g. the
+// full-delegation kernel governor's in-flight axi session). Governors without
+// a Close method are left untouched. Errors are logged, not propagated — a
+// run's success does not hinge on session teardown.
+func closeGovernor(gov governance.Governor) {
+	closer, ok := gov.(interface{ Close() error })
+	if !ok {
+		return
+	}
+	if err := closer.Close(); err != nil {
+		logging.Error().Add(logging.ErrorField(err)).Msg("failed to close run governor")
 	}
 }
 

--- a/application/engine.go
+++ b/application/engine.go
@@ -324,6 +324,22 @@ func (e *Engine) executeRun(ctx context.Context, runID, goal string, vars map[st
 		return r, errors.New("max steps exceeded")
 	}
 
+	// Verify the run's evidence chain before declaring success. Under full
+	// axi delegation the Governor accumulates one tamper-evident chain per
+	// run; a broken chain means the audit trail was tampered with, which is
+	// a run failure, not a silent success.
+	if r.Status == agent.RunStatusCompleted {
+		if err := verifyRunEvidence(machineCtx.Governor); err != nil {
+			r.Fail(err.Error())
+			runLedger.RecordRunFailed(r.CurrentState, err.Error())
+			e.publishEvent(ctx, runID, event.TypeRunFailed, event.RunFailedPayload{
+				Error: err.Error(), State: r.CurrentState, Duration: r.Duration(),
+			})
+			e.updateRun(ctx, r)
+			return r, err
+		}
+	}
+
 	// Log completion
 	logging.Info().
 		Add(logging.RunID(runID)).
@@ -832,6 +848,21 @@ func (e *Engine) publishEvent(ctx context.Context, runID string, eventType event
 	if err := e.eventStore.Append(ctx, evt); err != nil {
 		logging.Error().Add(logging.RunID(runID)).Add(logging.ErrorField(err)).Msg("failed to publish event")
 	}
+}
+
+// verifyRunEvidence verifies the run's axi-native evidence chain when the
+// Governor exposes one (full axi delegation). Governors without an evidence
+// chain (passthrough, approval-only axi) verify trivially. A broken chain is
+// returned as an error so the engine fails the run.
+func verifyRunEvidence(gov governance.Governor) error {
+	verifier, ok := gov.(governance.EvidenceVerifier)
+	if !ok {
+		return nil
+	}
+	if err := verifier.VerifyEvidenceChain(); err != nil {
+		return fmt.Errorf("run evidence chain verification failed: %w", err)
+	}
+	return nil
 }
 
 // closeGovernor releases a per-run Governor that holds resources (e.g. the

--- a/application/engine.go
+++ b/application/engine.go
@@ -279,6 +279,10 @@ func (e *Engine) executeRun(ctx context.Context, runID, goal string, vars map[st
 					Add(logging.RunID(runID)).
 					Add(logging.State(r.CurrentState)).
 					Msg("run paused for human input")
+				// Capture the governor's evidence-chain snapshot onto the run
+				// so the resumed segment continues ONE physical chain across
+				// the pause (the deferred closeGovernor tears the session down).
+				captureGovernorEvidence(r, machineCtx.Governor)
 				e.publishEvent(ctx, runID, event.TypeRunPaused, nil)
 				e.updateRun(ctx, r)
 				return r, err
@@ -431,8 +435,14 @@ func (e *Engine) ResumeWithInput(ctx context.Context, run *agent.Run, input stri
 	run.ClearPendingQuestion()
 	run.Resume()
 
-	// Create supporting components (fresh for this segment)
+	// Create supporting components for this segment. The budget is SEEDED with
+	// the tool calls already consumed before the pause (the persisted count of
+	// tool-result evidence), so the run-spanning tool_calls limit survives the
+	// pause instead of silently resetting to full.
 	budget := policy.NewBudget(e.budgetLimits)
+	if consumed := run.ConsumedToolCalls(); consumed > 0 {
+		_ = budget.Consume("tool_calls", consumed)
+	}
 	runLedger := ledger.New(run.ID)
 
 	// Record human input response in ledger
@@ -444,6 +454,12 @@ func (e *Engine) ResumeWithInput(ctx context.Context, run *agent.Run, input stri
 	machineCtx.Transitions = e.transitions
 	machineCtx.Governor = e.govFactory.Governor(ctx, budget)
 	defer closeGovernor(machineCtx.Governor)
+
+	// Rehydrate the evidence chain from the snapshot captured at pause time so
+	// the resumed run continues ONE continuous, tamper-evident chain.
+	if err := rehydrateGovernorEvidence(machineCtx.Governor, run.GovernanceEvidence); err != nil {
+		return nil, fmt.Errorf("failed to rehydrate evidence chain: %w", err)
+	}
 
 	// Create state machine
 	machine, err := statemachine.NewAgentMachine()
@@ -484,6 +500,10 @@ func (e *Engine) ResumeWithInput(ctx context.Context, run *agent.Run, input stri
 					Add(logging.RunID(run.ID)).
 					Add(logging.State(run.CurrentState)).
 					Msg("run paused for human input")
+				// Re-capture the (now-extended) evidence chain so a further
+				// resume continues the same continuous chain.
+				captureGovernorEvidence(run, machineCtx.Governor)
+				e.updateRun(ctx, run)
 				return run, err
 			}
 
@@ -505,6 +525,17 @@ func (e *Engine) ResumeWithInput(ctx context.Context, run *agent.Run, input stri
 		run.Fail("max steps exceeded")
 		runLedger.RecordRunFailed(run.CurrentState, "max steps exceeded")
 		return run, errors.New("max steps exceeded")
+	}
+
+	// Verify the run's evidence chain before declaring success — the resumed
+	// run carries ONE continuous chain across the pause, so a broken chain is
+	// a run failure, exactly as on the initial path (parity with executeRun).
+	if run.Status == agent.RunStatusCompleted {
+		if err := verifyRunEvidence(machineCtx.Governor); err != nil {
+			run.Fail(err.Error())
+			runLedger.RecordRunFailed(run.CurrentState, err.Error())
+			return run, err
+		}
 	}
 
 	// Log completion
@@ -863,6 +894,40 @@ func verifyRunEvidence(gov governance.Governor) error {
 		return fmt.Errorf("run evidence chain verification failed: %w", err)
 	}
 	return nil
+}
+
+// captureGovernorEvidence persists the Governor's evidence-chain snapshot onto
+// the run so a human-input pause does not discard it: the resumed segment
+// rehydrates from it to continue ONE continuous chain. Governors without an
+// evidence chain (passthrough, approval-only axi) leave the run untouched.
+// Best-effort — a snapshot error is logged, not fatal to the pause.
+func captureGovernorEvidence(r *agent.Run, gov governance.Governor) {
+	snapshotter, ok := gov.(governance.EvidenceSnapshotter)
+	if !ok {
+		return
+	}
+	data, err := snapshotter.EvidenceSnapshot()
+	if err != nil {
+		logging.Error().Add(logging.RunID(r.ID)).Add(logging.ErrorField(err)).
+			Msg("failed to snapshot governance evidence at pause")
+		return
+	}
+	r.GovernanceEvidence = data
+}
+
+// rehydrateGovernorEvidence restores a previously captured evidence-chain
+// snapshot into the resumed run's Governor so the chain is continuous across
+// the pause. Governors without rehydration support (or an empty snapshot) are
+// a no-op.
+func rehydrateGovernorEvidence(gov governance.Governor, data json.RawMessage) error {
+	if len(data) == 0 {
+		return nil
+	}
+	rehydrator, ok := gov.(governance.EvidenceRehydrator)
+	if !ok {
+		return nil
+	}
+	return rehydrator.RehydrateEvidence(data)
 }
 
 // closeGovernor releases a per-run Governor that holds resources (e.g. the

--- a/application/engine_test.go
+++ b/application/engine_test.go
@@ -2020,3 +2020,184 @@ func TestNewEngineWithOptions_AllOptions(t *testing.T) {
 		t.Errorf("expected budget limit 50, got %d", engine.budgetLimits["tool_calls"])
 	}
 }
+
+// --- Full axi delegation (KernelFactory default) integration tests ---
+
+// Under the full-delegation default, a run-level tool_calls budget must
+// survive a human-input pause: the budget consumed before the pause is not
+// reset to full on resume (P1-1). With a budget of 1, the pre-pause tool call
+// consumes it; the post-resume tool call must be denied as budget-exhausted.
+func TestResume_BudgetSurvivesPause_KernelDefault(t *testing.T) {
+	readTool := newTestTool("read_file", true)
+	registry := newTestRegistry(readTool)
+	eligibility := newTestEligibility(map[agent.State][]string{
+		agent.StateExplore: {"read_file"},
+	})
+
+	scriptedPlanner := planner.NewScriptedPlanner(
+		// Pre-pause: explore, call tool (consumes the only budget slot), ask human.
+		planner.ScriptStep{
+			ExpectState: agent.StateIntake,
+			Decision:    agent.NewTransitionDecision(agent.StateExplore, "explore"),
+		},
+		planner.ScriptStep{
+			ExpectState: agent.StateExplore,
+			Decision:    agent.NewCallToolDecision("read_file", json.RawMessage(`{}`), "first call before pause"),
+		},
+		planner.ScriptStep{
+			ExpectState: agent.StateExplore,
+			Decision: agent.Decision{
+				Type:     agent.DecisionAskHuman,
+				AskHuman: &agent.AskHumanDecision{Question: "continue?", Options: []string{"yes"}},
+			},
+		},
+		// Post-resume: try another tool call — must be budget-exhausted (no reset).
+		planner.ScriptStep{
+			ExpectState: agent.StateExplore,
+			Decision:    agent.NewCallToolDecision("read_file", json.RawMessage(`{}`), "second call after resume - must be denied"),
+		},
+	)
+
+	engine, err := NewEngine(EngineConfig{
+		Registry:     registry,
+		Planner:      scriptedPlanner,
+		Eligibility:  eligibility,
+		BudgetLimits: map[string]int{"tool_calls": 1},
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	ctx := context.Background()
+	run, err := engine.Run(ctx, "budget across pause")
+	if !errors.Is(err, agent.ErrAwaitingHumanInput) {
+		t.Fatalf("expected pause, got %v", err)
+	}
+	if run.ConsumedToolCalls() != 1 {
+		t.Fatalf("expected 1 tool call consumed before pause, got %d", run.ConsumedToolCalls())
+	}
+
+	run, err = engine.ResumeWithInput(ctx, run, "yes")
+	if !errors.Is(err, policy.ErrBudgetExceeded) {
+		t.Fatalf("budget must NOT reset across pause: expected ErrBudgetExceeded on resume, got %v", err)
+	}
+	if run.Status != agent.RunStatusFailed {
+		t.Fatalf("expected failed run after budget exhaustion, got %s", run.Status)
+	}
+}
+
+// Under the full-delegation default, the evidence chain is continuous across a
+// human-input pause and verifies end-to-end at completion (P1-1): a tool call
+// before the pause and one after both land on ONE chain, and the run completes
+// successfully (which only happens if verifyRunEvidence passes).
+func TestResume_EvidenceChainContinuousAcrossPause_KernelDefault(t *testing.T) {
+	readTool := newTestTool("read_file", true)
+	registry := newTestRegistry(readTool)
+	eligibility := newTestEligibility(map[agent.State][]string{
+		agent.StateExplore: {"read_file"},
+	})
+
+	scriptedPlanner := planner.NewScriptedPlanner(
+		planner.ScriptStep{
+			ExpectState: agent.StateIntake,
+			Decision:    agent.NewTransitionDecision(agent.StateExplore, "explore"),
+		},
+		planner.ScriptStep{
+			ExpectState: agent.StateExplore,
+			Decision:    agent.NewCallToolDecision("read_file", json.RawMessage(`{"n":1}`), "pre-pause call"),
+		},
+		planner.ScriptStep{
+			ExpectState: agent.StateExplore,
+			Decision: agent.Decision{
+				Type:     agent.DecisionAskHuman,
+				AskHuman: &agent.AskHumanDecision{Question: "continue?", Options: []string{"yes"}},
+			},
+		},
+		planner.ScriptStep{
+			ExpectState: agent.StateExplore,
+			Decision:    agent.NewCallToolDecision("read_file", json.RawMessage(`{"n":2}`), "post-resume call"),
+		},
+		planner.ScriptStep{
+			ExpectState: agent.StateExplore,
+			Decision:    agent.NewTransitionDecision(agent.StateDecide, "decide"),
+		},
+		planner.ScriptStep{
+			ExpectState: agent.StateDecide,
+			Decision:    agent.NewFinishDecision("done", json.RawMessage(`{"ok":true}`)),
+		},
+	)
+
+	engine, err := NewEngine(EngineConfig{
+		Registry:     registry,
+		Planner:      scriptedPlanner,
+		Eligibility:  eligibility,
+		BudgetLimits: map[string]int{"tool_calls": 5},
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	ctx := context.Background()
+	run, err := engine.Run(ctx, "evidence across pause")
+	if !errors.Is(err, agent.ErrAwaitingHumanInput) {
+		t.Fatalf("expected pause, got %v", err)
+	}
+	if len(run.GovernanceEvidence) == 0 {
+		t.Fatal("expected governance evidence snapshot captured at pause")
+	}
+
+	run, err = engine.ResumeWithInput(ctx, run, "yes")
+	if err != nil {
+		t.Fatalf("ResumeWithInput: %v", err)
+	}
+	if run.Status != agent.RunStatusCompleted {
+		t.Fatalf("expected completed run (evidence chain must verify), got %s err=%v", run.Status, run.Error)
+	}
+	// Two tool results plus the human-input evidence on the run aggregate.
+	if run.ConsumedToolCalls() != 2 {
+		t.Fatalf("expected 2 tool calls across the run, got %d", run.ConsumedToolCalls())
+	}
+}
+
+// Context cancellation mid-run releases the held axi session cleanly (no hang,
+// no leaked goroutine — caught by goleak) and fails the run.
+func TestRun_ContextCancelMidRun_KernelDefault(t *testing.T) {
+	readTool := newTestTool("read_file", true)
+	registry := newTestRegistry(readTool)
+	eligibility := newTestEligibility(map[agent.State][]string{
+		agent.StateExplore: {"read_file"},
+	})
+
+	scriptedPlanner := planner.NewScriptedPlanner(
+		planner.ScriptStep{
+			ExpectState: agent.StateIntake,
+			Decision:    agent.NewTransitionDecision(agent.StateExplore, "explore"),
+		},
+		planner.ScriptStep{
+			ExpectState: agent.StateExplore,
+			Decision:    agent.NewCallToolDecision("read_file", json.RawMessage(`{}`), "call before cancel"),
+		},
+	)
+
+	engine, err := NewEngine(EngineConfig{
+		Registry:     registry,
+		Planner:      scriptedPlanner,
+		Eligibility:  eligibility,
+		BudgetLimits: map[string]int{"tool_calls": 5},
+		MaxSteps:     10,
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the run starts stepping
+
+	run, runErr := engine.Run(ctx, "cancel mid-run")
+	if runErr == nil {
+		t.Fatal("expected an error from a cancelled run")
+	}
+	if run.Status != agent.RunStatusFailed {
+		t.Fatalf("expected failed run on cancel, got %s", run.Status)
+	}
+}

--- a/application/evidence_verification_test.go
+++ b/application/evidence_verification_test.go
@@ -1,0 +1,62 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	axidomain "go.klarlabs.de/axi/domain"
+
+	"go.klarlabs.de/agent/domain/policy"
+	"go.klarlabs.de/agent/infrastructure/governance"
+)
+
+// stubVerifierGovernor is a Governor that also exposes EvidenceVerifier with a
+// controllable verification result, to test the engine's run-completion
+// evidence-chain check without touching axi internals.
+type stubVerifierGovernor struct {
+	verifyErr error
+}
+
+func (s *stubVerifierGovernor) Authorize(context.Context, governance.ToolRequest) (governance.Authorization, error) {
+	return governance.Authorization{Decision: governance.DecisionAllow}, nil
+}
+
+func (s *stubVerifierGovernor) Commit(context.Context, governance.ToolRequest, governance.Outcome) (governance.Commit, error) {
+	return governance.Commit{Remaining: -1}, nil
+}
+
+func (s *stubVerifierGovernor) BudgetSnapshot() policy.BudgetSnapshot {
+	return policy.NewBudget(nil).Snapshot()
+}
+
+func (s *stubVerifierGovernor) OwnsApproval() bool { return true }
+
+func (s *stubVerifierGovernor) VerifyEvidenceChain() error { return s.verifyErr }
+
+func (s *stubVerifierGovernor) EvidenceCount() int { return 0 }
+
+func TestVerifyRunEvidence_NonVerifierGovernorPasses(t *testing.T) {
+	// A Governor without an evidence chain verifies trivially.
+	if err := verifyRunEvidence(governance.NewPassthrough(policy.NewBudget(nil), nil)); err != nil {
+		t.Fatalf("non-verifier governor must pass, got: %v", err)
+	}
+}
+
+func TestVerifyRunEvidence_ValidChainPasses(t *testing.T) {
+	if err := verifyRunEvidence(&stubVerifierGovernor{verifyErr: nil}); err != nil {
+		t.Fatalf("valid chain must pass, got: %v", err)
+	}
+}
+
+func TestVerifyRunEvidence_BrokenChainFails(t *testing.T) {
+	broken := &axidomain.ErrChainBroken{Index: 1, Reason: "Hash mismatch"}
+	err := verifyRunEvidence(&stubVerifierGovernor{verifyErr: broken})
+	if err == nil {
+		t.Fatal("broken chain must fail run evidence verification")
+	}
+	var chainErr *axidomain.ErrChainBroken
+	if !errors.As(err, &chainErr) {
+		t.Fatalf("want wrapped ErrChainBroken, got %T: %v", err, err)
+	}
+}

--- a/application/main_test.go
+++ b/application/main_test.go
@@ -1,0 +1,14 @@
+package application
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain installs goleak so a leaked per-run governance goroutine — e.g. a
+// full-delegation kernel governor whose held axi session is never Closed —
+// fails CI instead of silently leaking across runs.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/domain/agent/run.go
+++ b/domain/agent/run.go
@@ -39,6 +39,12 @@ type Run struct {
 	PendingQuestion *PendingQuestion `json:"pending_question,omitempty"`
 	ParentRunID     string           `json:"parent_run_id,omitempty"`
 	TaskID          string           `json:"task_id,omitempty"`
+	// GovernanceEvidence persists the run's axi evidence-chain snapshot across
+	// a human-input pause so the resumed run continues ONE continuous,
+	// tamper-evident chain rather than starting a fresh one. It is opaque to
+	// the domain (an axi SessionSnapshot); only the full-delegation governor
+	// reads and writes it. Empty when no governor exposes an evidence chain.
+	GovernanceEvidence json.RawMessage `json:"governance_evidence,omitempty"`
 }
 
 // NewRun creates a new run with the given ID and initial state.
@@ -104,6 +110,21 @@ func (r *Run) Resume() {
 // AddEvidence appends evidence to the run.
 func (r *Run) AddEvidence(e Evidence) {
 	r.Evidence = append(r.Evidence, e)
+}
+
+// ConsumedToolCalls reports how many successful tool calls the run has
+// recorded. Each successful act-state tool call appends one tool-result
+// evidence record, so this is the persisted count of tool_calls budget
+// consumed — the source for seeding a resumed run's budget so a human-input
+// pause does not reset it to full.
+func (r *Run) ConsumedToolCalls() int {
+	n := 0
+	for _, e := range r.Evidence {
+		if e.Type == EvidenceToolResult {
+			n++
+		}
+	}
+	return n
 }
 
 // SetVar sets a variable in the run context.

--- a/domain/agent/run_test.go
+++ b/domain/agent/run_test.go
@@ -176,6 +176,22 @@ func TestRun_AddEvidence(t *testing.T) {
 	}
 }
 
+func TestRun_ConsumedToolCalls(t *testing.T) {
+	run := NewRun("test", "goal")
+	if got := run.ConsumedToolCalls(); got != 0 {
+		t.Fatalf("fresh run consumed = %d, want 0", got)
+	}
+
+	run.AddEvidence(NewToolEvidence("read", json.RawMessage(`{}`)))
+	run.AddEvidence(NewHumanEvidence(json.RawMessage(`{"q":"?"}`))) // not a tool call
+	run.AddEvidence(NewToolEvidence("write", json.RawMessage(`{}`)))
+	run.AddEvidence(NewSystemEvidence("note")) // not a tool call
+
+	if got := run.ConsumedToolCalls(); got != 2 {
+		t.Fatalf("ConsumedToolCalls = %d, want 2 (only tool results count)", got)
+	}
+}
+
 func TestRun_Variables(t *testing.T) {
 	run := NewRun("test", "goal")
 

--- a/infrastructure/governance/axi.go
+++ b/infrastructure/governance/axi.go
@@ -49,8 +49,10 @@ func NewAxiFactory(approver policy.Approver) (*AxiFactory, error) {
 	return &AxiFactory{kernel: kernel, approver: approver}, nil
 }
 
-// Governor returns a Governor for one run, bound to that run's budget.
-func (f *AxiFactory) Governor(budget *policy.Budget) Governor {
+// Governor returns a Governor for one run, bound to that run's budget. The
+// approval-only axi governor holds no per-run session, so ctx is unused (each
+// gate Execute carries its own ctx from Authorize).
+func (f *AxiFactory) Governor(_ context.Context, budget *policy.Budget) Governor {
 	return &axiGovernor{budget: budget, approver: f.approver, kernel: f.kernel}
 }
 

--- a/infrastructure/governance/axi.go
+++ b/infrastructure/governance/axi.go
@@ -22,15 +22,16 @@ const (
 
 // AxiFactory builds per-run axi-backed Governors that share one kernel.
 //
-// Governance split (axi v1.4.0): the destructive-tool approval gate is
-// delegated to axi — its native, effect-gated pause is the spec's headline
-// safety primitive. Run-level tool-call budget stays in agent-go: axi's
-// ExecutionBudget is per-session (one action's capability fan-out) and
-// cannot express a run-spanning tool count without a held-session API axi
-// does not yet expose. The evidence trail likewise stays on the engine's
-// run ledger, which is one chain per run rather than the fragmented
-// per-call chains axi would produce. See doc.go for the path to full
-// budget/evidence delegation (axi held-session API).
+// Governance split: the destructive-tool approval gate is delegated to axi —
+// its native, effect-gated pause is the spec's headline safety primitive —
+// while run-level tool-call budget stays in agent-go and the evidence trail
+// stays on the engine's run ledger. This is the approval-only delegation tier
+// and the engine default.
+//
+// For FULL delegation — budget, approval, and the evidence chain all routed
+// through ONE axi session per run — use KernelFactory instead (see kernel.go
+// and doc.go). AxiFactory remains available for callers that want only the
+// approval gate delegated.
 type AxiFactory struct {
 	kernel   *axi.Kernel
 	approver policy.Approver

--- a/infrastructure/governance/axi_contract_test.go
+++ b/infrastructure/governance/axi_contract_test.go
@@ -1,0 +1,128 @@
+package governance
+
+import (
+	"context"
+	"testing"
+
+	"go.klarlabs.de/axi"
+	axidomain "go.klarlabs.de/axi/domain"
+)
+
+// isBudgetExceeded relies on a substring of axi's per-session budget-exceeded
+// error message, because axi v1.4.0 does not yet expose a typed sentinel. This
+// contract test pins that coupling: it drives a real axi session past its
+// MaxCapabilityInvocations limit and asserts the resulting error still matches
+// isBudgetExceeded. If an axi upgrade changes the wording, this test breaks
+// loudly instead of letting full-delegation budget enforcement silently fail.
+func TestContract_AxiBudgetExceededMatchesDetector(t *testing.T) {
+	const (
+		capName  = "contract.cap"
+		capExec  = "exec.contract.cap"
+		actName  = "contract.act"
+		actExec  = "exec.contract.act"
+		pluginID = "contract.plugin"
+	)
+
+	// invokeErr captures the error axi returns from CapabilityInvoker.Invoke
+	// when the budget is tripped — the exact seam the full-delegation governor
+	// reads (its runSessionExecutor returns caps.Invoke's error on respCh).
+	invokeErrCh := make(chan error, 1)
+
+	kernel := axi.New()
+	kernel.WithBudget(axi.Budget{MaxCapabilityInvocations: 1})
+	kernel.RegisterCapabilityExecutor(capExec, contractCapExecutor{})
+	kernel.RegisterActionExecutor(actExec, &contractActExecutor{invokeErrCh: invokeErrCh})
+	if err := kernel.RegisterPlugin(contractPlugin{
+		capName: capName, capExec: capExec,
+		actName: actName, actExec: actExec, pluginID: pluginID,
+	}); err != nil {
+		t.Fatalf("RegisterPlugin: %v", err)
+	}
+
+	if _, err := kernel.Execute(context.Background(), axi.Invocation{Action: actName}); err != nil {
+		t.Fatalf("kernel.Execute: %v", err)
+	}
+
+	select {
+	case err := <-invokeErrCh:
+		if err == nil {
+			t.Fatal("expected axi to fail the second capability invocation on budget")
+		}
+		if !isBudgetExceeded(err) {
+			t.Fatalf("axi budget-exceeded error no longer matches isBudgetExceeded; "+
+				"the substring contract changed — update isBudgetExceeded. err=%v", err)
+		}
+	default:
+		t.Fatal("executor did not report a CapabilityInvoker.Invoke error")
+	}
+}
+
+type contractCapExecutor struct{}
+
+func (contractCapExecutor) Execute(_ context.Context, _ any) (any, error) {
+	return struct{}{}, nil
+}
+
+// contractActExecutor invokes the capability twice within one session, so the
+// second Invoke trips MaxCapabilityInvocations:1. It reports the second
+// Invoke's error on invokeErrCh (mirroring the full-delegation governor, which
+// reads caps.Invoke's error directly rather than via the session result).
+type contractActExecutor struct {
+	invokeErrCh chan error
+}
+
+func (e *contractActExecutor) Execute(
+	_ context.Context,
+	_ any,
+	caps axidomain.CapabilityInvoker,
+) (axidomain.ExecutionResult, []axidomain.EvidenceRecord, error) {
+	_, _ = caps.Invoke("contract.cap", nil)
+	_, err := caps.Invoke("contract.cap", nil)
+	e.invokeErrCh <- err
+	return axidomain.ExecutionResult{Summary: "done"}, nil, nil
+}
+
+type contractPlugin struct {
+	capName, capExec string
+	actName, actExec string
+	pluginID         string
+}
+
+func (p contractPlugin) Contribute() (*axidomain.PluginContribution, error) {
+	cap, err := axidomain.NewCapabilityDefinition(
+		axidomain.CapabilityName(p.capName),
+		"contract capability",
+		axidomain.EmptyContract(),
+		axidomain.EmptyContract(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := cap.BindExecutor(axidomain.CapabilityExecutorRef(p.capExec)); err != nil {
+		return nil, err
+	}
+	req, err := axidomain.NewRequirementSet(axidomain.Requirement{Capability: axidomain.CapabilityName(p.capName)})
+	if err != nil {
+		return nil, err
+	}
+	act, err := axidomain.NewActionDefinition(
+		axidomain.ActionName(p.actName),
+		"contract action",
+		axidomain.EmptyContract(),
+		axidomain.EmptyContract(),
+		req,
+		axidomain.EffectProfile{Level: axidomain.EffectNone},
+		axidomain.IdempotencyProfile{IsIdempotent: false},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := act.BindExecutor(axidomain.ActionExecutorRef(p.actExec)); err != nil {
+		return nil, err
+	}
+	return axidomain.NewPluginContribution(
+		axidomain.PluginID(p.pluginID),
+		[]*axidomain.ActionDefinition{act},
+		[]*axidomain.CapabilityDefinition{cap},
+	)
+}

--- a/infrastructure/governance/axi_test.go
+++ b/infrastructure/governance/axi_test.go
@@ -13,7 +13,7 @@ func axiGov(t *testing.T, limit int, approver policy.Approver) Governor {
 	if err != nil {
 		t.Fatalf("NewAxiFactory: %v", err)
 	}
-	return f.Governor(policy.NewBudget(map[string]int{budgetKey: limit}))
+	return f.Governor(context.Background(), policy.NewBudget(map[string]int{budgetKey: limit}))
 }
 
 func TestAxi_NonApprovalToolAllowed(t *testing.T) {

--- a/infrastructure/governance/doc.go
+++ b/infrastructure/governance/doc.go
@@ -1,33 +1,51 @@
+// Delegation tiers for agent-go governance (spec § Changes Required #1).
+// The canonical package comment lives in governance.go; this file documents
+// the three Factory tiers and how full axi delegation works.
+//
+// Three Factories, increasing delegation:
+//
+//   - PassthroughFactory — budget + approval fully in-process (approval via
+//     the engine's approval middleware). For LLM-free scripted runs or tests
+//     that do not want a kernel. OwnsApproval reports false.
+//
+//   - AxiFactory — delegates only the destructive-tool approval gate to a
+//     shared axi.Kernel; run-level budget stays in agent-go and evidence on
+//     the engine ledger. OwnsApproval reports true. The default when
+//     EngineConfig.Governance is unset.
+//
+//   - KernelFactory — full delegation (Track F). Each agent run executes as
+//     ONE axi session, so budget, approval, and the evidence chain are all
+//     axi-native. OwnsApproval reports true. Select it with
+//     EngineConfig.Governance = NewKernelFactory(approver) (api.WithGovernance).
+//
+// How full delegation works without changing axi:
+//
+// axi's ExecutionBudget (MaxCapabilityInvocations) is enforced per session,
+// across every CapabilityInvoker.Invoke call within one in-flight action
+// execution (domain/execution.go: boundInvoker.checkInvocation, called from
+// every Invoke). A held session is therefore realised in agent-go (the
+// consumer) rather than added to axi: KernelFactory.Governor starts ONE
+// kernel.Execute(runSessionAction) on a goroutine whose
+// OrchestratorActionExecutor blocks on a channel. Each act-state tool call
+// drives one caps.Invoke through that in-flight session, so axi's per-session
+// budget enforcer counts run-level tool calls and fails the (N+1)th natively
+// with the budget error. The run loop stays statekit-driven; only the
+// governed tool gate routes through the kernel session. No held-session API
+// is added to axi — its independence is preserved.
+//
+//   - Budget — tool_calls maps onto the run session's
+//     ExecutionBudget.MaxCapabilityInvocations. axi is the authoritative
+//     enforcer (see TestKernel_AxiSessionIsAuthoritativeBudgetEnforcer); the
+//     local policy.Budget mirror only orders budget precedence before
+//     approval and keeps BudgetSnapshot in lockstep.
+//   - Approval — destructive tools drive the write-external gate action
+//     through the kernel, gated per call.
+//   - Evidence — each committed tool call appends one EvidenceRecord to the
+//     run's single axidomain.ExecutionSession, a tamper-evident chain per run
+//     verified at run completion via VerifyEvidenceChain.
+//
+// This supersedes the earlier scope boundary that kept budget and evidence in
+// agent-go pending an axi held-session API: the OrchestratorActionExecutor /
+// CapabilityInvoker pattern already enforces a run-spanning budget within one
+// session, so no axi change is required.
 package governance
-
-// Governance delegation to axi-go (agent-go spec § Changes Required #1).
-//
-// Active (default): the engine builds an AxiFactory unless EngineConfig.
-// Governance is set. The destructive-tool approval gate is delegated to a
-// shared axi.Kernel — the tool's risk annotations drive a write-external
-// effect profile, the kernel pauses the session at awaiting_approval, and
-// the configured approver settles it via Approve/Reject. When the factory
-// OwnsApproval, the engine drops its approval middleware so the gate is
-// enforced exactly once.
-//
-// Scope boundary (axi v1.4.0):
-//   - Approval — delegated to axi. Native, per-call, the spec's headline
-//     safety primitive.
-//   - Budget — stays run-level in agent-go. axi's ExecutionBudget is
-//     per-session (one action's capability fan-out) and cannot express a
-//     run-spanning tool count without a held-session / incremental-
-//     invocation handle that axi does not yet expose.
-//   - Evidence — stays on the engine's run ledger (one chain per run).
-//     Routing it through axi today would yield fragmented per-call chains,
-//     a regression for a run-level audit trail.
-//
-// Path to full delegation: an axi held-session API (open a session with a
-// run budget, invoke capabilities against it across the agent loop, close
-// it) would let budget and the evidence chain move to axi as one session
-// per run. That is an axi-side change — track it in the axi spec. Until
-// then this split is the faithful, shippable boundary.
-//
-// Opt out with EngineConfig.Governance = NewPassthroughFactory(approver):
-// budget + approval stay fully in-process (approval via the engine
-// middleware), e.g. for LLM-free scripted runs or tests that do not want a
-// kernel.

--- a/infrastructure/governance/doc.go
+++ b/infrastructure/governance/doc.go
@@ -10,13 +10,14 @@
 //
 //   - AxiFactory — delegates only the destructive-tool approval gate to a
 //     shared axi.Kernel; run-level budget stays in agent-go and evidence on
-//     the engine ledger. OwnsApproval reports true. The default when
-//     EngineConfig.Governance is unset.
+//     the engine ledger. OwnsApproval reports true. Selectable via
+//     api.WithGovernance(NewAxiFactory(approver)).
 //
 //   - KernelFactory — full delegation (Track F). Each agent run executes as
 //     ONE axi session, so budget, approval, and the evidence chain are all
-//     axi-native. OwnsApproval reports true. Select it with
-//     EngineConfig.Governance = NewKernelFactory(approver) (api.WithGovernance).
+//     axi-native. OwnsApproval reports true. This is the DEFAULT when
+//     EngineConfig.Governance is unset — the only tier that satisfies the
+//     spec non-negotiable "budget AND approval always through axi".
 //
 // How full delegation works without changing axi:
 //
@@ -26,26 +27,44 @@
 // every Invoke). A held session is therefore realised in agent-go (the
 // consumer) rather than added to axi: KernelFactory.Governor starts ONE
 // kernel.Execute(runSessionAction) on a goroutine whose
-// OrchestratorActionExecutor blocks on a channel. Each act-state tool call
-// drives one caps.Invoke through that in-flight session, so axi's per-session
-// budget enforcer counts run-level tool calls and fails the (N+1)th natively
-// with the budget error. The run loop stays statekit-driven; only the
-// governed tool gate routes through the kernel session. No held-session API
-// is added to axi — its independence is preserved.
+// OrchestratorActionExecutor blocks on a channel, scoped to the run ctx (so
+// cancellation/MaxDuration propagate). Each SUCCESSFUL act-state tool call
+// drives one caps.Invoke through that in-flight session at Commit time, so
+// axi's per-session budget enforcer counts run-level tool calls and fails the
+// (N+1)th natively. The run loop stays statekit-driven; only the governed tool
+// gate routes through the kernel session. No held-session API is added to axi
+// — its independence is preserved.
 //
 //   - Budget — tool_calls maps onto the run session's
-//     ExecutionBudget.MaxCapabilityInvocations. axi is the authoritative
-//     enforcer (see TestKernel_AxiSessionIsAuthoritativeBudgetEnforcer); the
-//     local policy.Budget mirror only orders budget precedence before
-//     approval and keeps BudgetSnapshot in lockstep.
+//     ExecutionBudget.MaxCapabilityInvocations. A slot is consumed only on
+//     tool SUCCESS (at Commit), matching the passthrough and approval-only
+//     Governors: a failed or denied tool burns nothing. axi is the
+//     authoritative count of successful invocations within a segment (see
+//     TestKernel_AxiSessionIsAuthoritativeBudgetEnforcer). The local
+//     policy.Budget mirror is the authoritative PRECEDENCE gate, checked
+//     (non-consuming) at Authorize before approval; it is the sole gate when
+//     the remaining budget is zero, because axi treats
+//     MaxCapabilityInvocations:0 as "no limit" — so the governor never
+//     delegates a session for a non-positive remaining budget, and a zero
+//     budget can never leak through as unlimited.
 //   - Approval — destructive tools drive the write-external gate action
 //     through the kernel, gated per call.
 //   - Evidence — each committed tool call appends one EvidenceRecord to the
 //     run's single axidomain.ExecutionSession, a tamper-evident chain per run
-//     verified at run completion via VerifyEvidenceChain.
+//     verified at run completion via VerifyEvidenceChain. Across a human-input
+//     pause the chain is ONE continuous physical chain: the engine captures a
+//     SessionSnapshot (axi's public Snapshot API) onto the run aggregate at
+//     pause and rehydrates it via SessionFromSnapshot on resume, and the
+//     run-spanning budget is seeded from the persisted consumed tool-call
+//     count so it is not reset to full.
 //
 // This supersedes the earlier scope boundary that kept budget and evidence in
 // agent-go pending an axi held-session API: the OrchestratorActionExecutor /
 // CapabilityInvoker pattern already enforces a run-spanning budget within one
 // session, so no axi change is required.
+//
+// axi v1.4.0 note: axi's budget-exceeded error is a formatted string, not a
+// typed sentinel, so isBudgetExceeded does a substring match. A contract test
+// (TestContract_AxiBudgetExceededMatchesDetector) pins that coupling so an axi
+// upgrade that changes the wording breaks loudly.
 package governance

--- a/infrastructure/governance/export_test.go
+++ b/infrastructure/governance/export_test.go
@@ -1,0 +1,26 @@
+package governance
+
+import axidomain "go.klarlabs.de/axi/domain"
+
+// corruptEvidence is a test-only hook that tampers with a record on the run
+// chain so verification failure can be exercised. It lives in _test.go so it
+// is never compiled into production binaries. It round-trips the session
+// through axi's public snapshot API, mutates the record's Value while leaving
+// its Hash untouched, and reloads — so VerifyEvidenceChain recomputes a
+// mismatching hash. No axi internals are touched; the chain is otherwise
+// append-only. The g.evidence write is guarded by g.mu.
+func (g *kernelGovernor) corruptEvidence(index int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	snap := g.evidence.ToSnapshot()
+	if index < 0 || index >= len(snap.Evidence) {
+		return
+	}
+	snap.Evidence[index].Value = "tampered"
+	reloaded, err := axidomain.SessionFromSnapshot(snap)
+	if err != nil {
+		return
+	}
+	g.evidence = reloaded
+}

--- a/infrastructure/governance/governance.go
+++ b/infrastructure/governance/governance.go
@@ -130,8 +130,11 @@ type Governor interface {
 // holds one Factory (so shared state like an axi.Kernel is built once) and
 // asks it for a Governor at the start of each run.
 type Factory interface {
-	// Governor returns a Governor for one run over the given budget.
-	Governor(budget *policy.Budget) Governor
+	// Governor returns a Governor for one run over the given budget, scoped to
+	// ctx. Governors that hold a per-run resource (the full-delegation kernel
+	// governor's in-flight axi session) bind it to ctx so the run's
+	// cancellation and MaxDuration propagate into the held session.
+	Governor(ctx context.Context, budget *policy.Budget) Governor
 	// OwnsApproval reports whether Governors from this Factory enforce
 	// approval, so the engine can drop its approval middleware once, at
 	// construction, rather than per run.

--- a/infrastructure/governance/governance.go
+++ b/infrastructure/governance/governance.go
@@ -8,27 +8,20 @@
 // The domain/policy package keeps its interfaces (Budget, Approval,
 // Eligibility); this package binds them to an implementation.
 //
-// Two implementations satisfy Governor:
+// Three implementations satisfy Governor (see doc.go):
 //
-//   - Passthrough — the in-process implementation backed by domain/policy
-//     (Budget, Approver). Behaviour-identical to the pre-delegation engine.
-//     Built by default. Approval is left to the engine's approval
-//     middleware (OwnsApproval reports false).
+//   - Passthrough — in-process, backed by domain/policy (Budget, Approver).
+//     Approval is left to the engine's approval middleware (OwnsApproval
+//     reports false).
 //
-//   - axiGovernor (build tag "axi") — routes every act-state tool call
-//     through an axi.Kernel, so budget, approval, and the evidence trail
-//     all come from the single axi governance kernel (OwnsApproval reports
-//     true; the engine drops its approval middleware).
+//   - axiGovernor — delegates only the destructive-tool approval gate to a
+//     shared axi.Kernel; run-level budget stays in agent-go (OwnsApproval
+//     reports true). The default.
 //
-// Activation is deferred until the toolchain bump that axi-go requires:
-//
-//  1. bump the agent-go module go directive to 1.26.2 (axi-go's floor)
-//  2. add `require go.klarlabs.de/axi v1.4.0` to go.mod
-//  3. build and test with `-tags axi`
-//  4. construct the engine's per-run Governor with NewAxi(...) instead of
-//     NewPassthrough(...)
-//
-// See doc.go for the full migration checklist.
+//   - kernelGovernor — full delegation: each run is ONE axi session, so
+//     budget, approval, and the evidence chain are all axi-native
+//     (OwnsApproval reports true). Select via api.WithGovernance(
+//     NewKernelFactory(approver)).
 package governance
 
 import (

--- a/infrastructure/governance/kernel.go
+++ b/infrastructure/governance/kernel.go
@@ -230,17 +230,23 @@ func (g *kernelGovernor) consumeStep() {
 }
 
 // invokeStep sends one tool call into the in-flight run session and waits for
-// axi's budget verdict.
+// axi's budget verdict. It never blocks past the run session's lifetime: once
+// the session is closed (doneCh), it returns errRunSessionClosed instead of
+// deadlocking on a vanished receiver.
 func (g *kernelGovernor) invokeStep(ctx context.Context, req ToolRequest) error {
 	respCh := make(chan stepResponse, 1)
 	select {
 	case g.reqCh <- stepRequest{input: req.ToolName, respCh: respCh}:
+	case <-g.doneCh:
+		return errRunSessionClosed
 	case <-ctx.Done():
 		return ctx.Err()
 	}
 	select {
 	case resp := <-respCh:
 		return resp.err
+	case <-g.doneCh:
+		return errRunSessionClosed
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/infrastructure/governance/kernel.go
+++ b/infrastructure/governance/kernel.go
@@ -1,0 +1,448 @@
+package governance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"go.klarlabs.de/axi"
+	axidomain "go.klarlabs.de/axi/domain"
+
+	"go.klarlabs.de/agent/domain/policy"
+)
+
+// Full budget+evidence delegation to axi (spec § Changes Required #1, Track F).
+//
+// The approval-only AxiFactory delegates just the destructive-tool gate to
+// axi; run-level budget and the evidence trail still live in agent-go. The
+// KernelFactory closes that gap: each agent RUN executes as ONE axi session,
+// so budget (run-spanning tool count), approval (per-effect gate), and the
+// evidence chain are all axi-native.
+//
+// Design — one axi session per run, no axi changes:
+//
+// axi's ExecutionBudget (MaxCapabilityInvocations) is enforced per session,
+// across every CapabilityInvoker.Invoke call made within one in-flight
+// action execution. A held session is therefore realised in agent-go (the
+// consumer) rather than added to axi: KernelFactory.Governor starts ONE
+// kernel.Execute(runSessionAction) on a goroutine whose
+// OrchestratorActionExecutor blocks on a channel. Each act-state tool call
+// drives one caps.Invoke through that in-flight session, so axi's budget
+// enforcer counts tool calls across the whole run and fails the (N+1)th
+// natively with the budget error. The run loop stays statekit-driven; only
+// the governed tool gate routes through the kernel session. axi is untouched
+// — no held-session API, preserving its independence.
+//
+// Evidence: each committed tool call appends one EvidenceRecord to the run's
+// axidomain.ExecutionSession, forming a single tamper-evident chain per run,
+// verifiable via VerifyEvidenceChain.
+//
+// Approval: destructive tools drive the write-external gate action through
+// the kernel (the same primitive AxiFactory uses), gated per call.
+
+const (
+	// runStepCapability is the no-op capability invoked once per act-state
+	// tool call so axi's per-session budget enforcer counts run-level tool
+	// calls. Its budget slot maps tool_calls → MaxCapabilityInvocations.
+	runStepCapability = "agent.run.step"
+	runStepExecRef    = "exec.cap.agent.run.step"
+	runSessionAction  = "agent.run.session"
+	runSessionExecRef = "exec.agent.run.session"
+	runPluginID       = "agent.run"
+)
+
+// EvidenceVerifier exposes the run's axi evidence chain for verification.
+// kernelGovernor implements it so callers can audit the single per-run chain.
+type EvidenceVerifier interface {
+	// VerifyEvidenceChain validates the run's evidence chain integrity,
+	// returning *axidomain.ErrChainBroken at the first tampered record.
+	VerifyEvidenceChain() error
+	// EvidenceCount reports the number of records on the run's chain.
+	EvidenceCount() int
+}
+
+// KernelFactory builds per-run kernel Governors that fully delegate budget,
+// approval, and evidence to axi. Each run gets its own axi.Kernel so the
+// run-level budget maps onto that kernel's per-session ExecutionBudget.
+type KernelFactory struct {
+	approver policy.Approver
+}
+
+// NewKernelFactory builds a Factory of full-delegation kernel Governors.
+// approver may be nil; an approval-requiring tool then fails closed with
+// ErrNoApprover at authorization time.
+func NewKernelFactory(approver policy.Approver) (*KernelFactory, error) {
+	return &KernelFactory{approver: approver}, nil
+}
+
+// Governor starts one axi session for the run and returns a Governor bound
+// to it. The session's ExecutionBudget.MaxCapabilityInvocations is taken
+// from the run's tool_calls budget, so axi enforces the run-level count.
+func (f *KernelFactory) Governor(budget *policy.Budget) Governor {
+	limit := budget.Remaining(budgetKey) // -1 when unlimited
+
+	kernel := axi.New()
+	if limit >= 0 {
+		kernel.WithBudget(axi.Budget{MaxCapabilityInvocations: limit})
+	}
+	kernel.RegisterCapabilityExecutor(runStepExecRef, runStepExecutor{})
+	kernel.RegisterActionExecutor(gateExecutorRef, gateExecutor{})
+
+	g := &kernelGovernor{
+		budget:   budget,
+		approver: f.approver,
+		kernel:   kernel,
+		reqCh:    make(chan stepRequest),
+		doneCh:   make(chan struct{}),
+	}
+
+	// Build the run-session executor that holds the in-flight session and
+	// drives one caps.Invoke per tool call. Register it together with the
+	// approval gate plugin.
+	exec := &runSessionExecutor{reqCh: g.reqCh, doneCh: g.doneCh}
+	kernel.RegisterActionExecutor(runSessionExecRef, exec)
+	if err := kernel.RegisterPlugin(runPlugin{}); err != nil {
+		g.startErr = fmt.Errorf("governance: register run session plugin: %w", err)
+		return g
+	}
+	if err := kernel.RegisterPlugin(gatePlugin{}); err != nil {
+		g.startErr = fmt.Errorf("governance: register approval gate: %w", err)
+		return g
+	}
+
+	// Build the run's evidence session: one tamper-evident chain per run.
+	session, err := axidomain.NewExecutionSession(
+		axidomain.ExecutionSessionID("run-evidence"),
+		runSessionAction,
+		nil,
+	)
+	if err != nil {
+		g.startErr = fmt.Errorf("governance: new evidence session: %w", err)
+		return g
+	}
+	g.evidence = session
+
+	// Launch the single in-flight run session. kernel.Execute blocks in the
+	// executor on reqCh until Close signals completion.
+	g.wg.Add(1)
+	go func() {
+		defer g.wg.Done()
+		_, runErr := kernel.Execute(context.Background(), axi.Invocation{Action: runSessionAction})
+		g.mu.Lock()
+		g.runErr = runErr
+		g.mu.Unlock()
+	}()
+
+	return g
+}
+
+// OwnsApproval reports true: the kernel enforces budget, approval, and
+// evidence, so the engine omits its approval middleware.
+func (f *KernelFactory) OwnsApproval() bool { return true }
+
+// stepRequest carries one act-state tool call into the in-flight run session.
+type stepRequest struct {
+	input  any
+	respCh chan stepResponse
+}
+
+// stepResponse returns the budget verdict for one tool call.
+type stepResponse struct {
+	err error
+}
+
+// kernelGovernor enforces budget, approval, and evidence for one run, all
+// through one axi session. Budget is enforced by the in-flight runSession
+// (caps.Invoke per tool call); approval via the gate action; evidence on a
+// single per-run chain.
+type kernelGovernor struct {
+	budget   *policy.Budget
+	approver policy.Approver
+	kernel   *axi.Kernel
+
+	reqCh  chan stepRequest
+	doneCh chan struct{}
+	wg     sync.WaitGroup
+
+	evidence *axidomain.ExecutionSession
+
+	mu       sync.Mutex
+	startErr error
+	runErr   error
+	closed   bool
+}
+
+// Authorize gates a tool: it drives one capability invocation through the
+// in-flight run session so axi's per-session budget counts the call, then —
+// for approval-requiring tools — runs the kernel's effect-gated pause.
+func (g *kernelGovernor) Authorize(ctx context.Context, req ToolRequest) (Authorization, error) {
+	if g.startErr != nil {
+		return Authorization{}, g.startErr
+	}
+
+	// Run-level budget: one capability invocation against the run session.
+	// axi's enforcer fails the (limit+1)th invocation natively.
+	if err := g.invokeStep(ctx, req); err != nil {
+		if isBudgetExceeded(err) {
+			return Authorization{Decision: DecisionBudgetExhausted}, nil
+		}
+		return Authorization{}, fmt.Errorf("governance: run session step: %w", err)
+	}
+
+	if !req.RequireApproval {
+		return Authorization{Decision: DecisionAllow}, nil
+	}
+	if g.approver == nil {
+		return Authorization{}, ErrNoApprover
+	}
+	return g.gateApproval(ctx, req)
+}
+
+// invokeStep sends one tool call into the in-flight run session and waits for
+// axi's budget verdict.
+func (g *kernelGovernor) invokeStep(ctx context.Context, req ToolRequest) error {
+	respCh := make(chan stepResponse, 1)
+	select {
+	case g.reqCh <- stepRequest{input: req.ToolName, respCh: respCh}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case resp := <-respCh:
+		return resp.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// gateApproval runs the kernel's write-external approval gate for a
+// destructive tool, settling it via the configured approver.
+func (g *kernelGovernor) gateApproval(ctx context.Context, req ToolRequest) (Authorization, error) {
+	out, err := g.kernel.Execute(ctx, axi.Invocation{Action: gateAction})
+	if err != nil {
+		return Authorization{}, fmt.Errorf("governance: axi approval gate: %w", err)
+	}
+	if !out.RequiresApproval {
+		return Authorization{Decision: DecisionAllow}, nil
+	}
+
+	resp, err := g.approver.Approve(ctx, policy.ApprovalRequest{
+		RunID:     req.RunID,
+		ToolName:  req.ToolName,
+		Input:     req.Input,
+		Reason:    req.Reason,
+		RiskLevel: req.RiskLevel,
+		Timestamp: time.Now(),
+	})
+	if err != nil {
+		return Authorization{}, err
+	}
+
+	principal := resp.Approver
+	if principal == "" {
+		principal = "agent-go"
+	}
+	decision := axidomain.ApprovalDecision{Principal: principal, Rationale: resp.Reason}
+	sessionID := string(out.SessionID)
+	if !resp.Approved {
+		reason := resp.Reason
+		if reason == "" {
+			reason = "approval denied"
+		}
+		if _, rerr := g.kernel.Reject(ctx, sessionID, decision); rerr != nil {
+			return Authorization{}, fmt.Errorf("governance: axi reject: %w", rerr)
+		}
+		return Authorization{Decision: DecisionDenied, Approver: resp.Approver, Reason: reason}, nil
+	}
+	if _, aerr := g.kernel.Approve(ctx, sessionID, decision); aerr != nil {
+		return Authorization{}, fmt.Errorf("governance: axi approve: %w", aerr)
+	}
+	return Authorization{Decision: DecisionAllow, Approver: resp.Approver}, nil
+}
+
+// Commit accounts a completed tool call: it consumes the local budget mirror
+// (so snapshots agree with the engine's ledger and run results) and appends
+// one EvidenceRecord to the run's single axi-native evidence chain.
+func (g *kernelGovernor) Commit(_ context.Context, req ToolRequest, out Outcome) (Commit, error) {
+	if out.Success {
+		_ = g.budget.Consume(budgetKey, 1)
+		g.evidence.AppendEvidence(axidomain.EvidenceRecord{
+			Kind:      "tool_result",
+			Source:    req.ToolName,
+			Value:     string(out.Output),
+			Timestamp: time.Now().UnixMilli(),
+		})
+	}
+	return Commit{Remaining: g.budget.Remaining(budgetKey)}, nil
+}
+
+// BudgetSnapshot returns the run budget's snapshot. The local mirror is kept
+// in lockstep with axi's session budget via invokeStep + Consume.
+func (g *kernelGovernor) BudgetSnapshot() policy.BudgetSnapshot { return g.budget.Snapshot() }
+
+// OwnsApproval reports true: the kernel owns budget, approval, and evidence.
+func (g *kernelGovernor) OwnsApproval() bool { return true }
+
+// VerifyEvidenceChain validates the run's single evidence chain.
+func (g *kernelGovernor) VerifyEvidenceChain() error {
+	return g.evidence.VerifyEvidenceChain()
+}
+
+// EvidenceCount reports the number of records on the run's evidence chain.
+func (g *kernelGovernor) EvidenceCount() int {
+	return len(g.evidence.Evidence())
+}
+
+// Close ends the in-flight run session and waits for the goroutine to finish.
+func (g *kernelGovernor) Close() error {
+	g.mu.Lock()
+	if g.closed {
+		g.mu.Unlock()
+		return nil
+	}
+	g.closed = true
+	g.mu.Unlock()
+
+	if g.startErr == nil {
+		close(g.doneCh)
+		g.wg.Wait()
+	}
+
+	g.mu.Lock()
+	runErr := g.runErr
+	g.mu.Unlock()
+	if runErr != nil && !errors.Is(runErr, errRunSessionClosed) {
+		return runErr
+	}
+	return nil
+}
+
+// corruptEvidence is a test-only hook (see kernel_test.go) that tampers with
+// a record on the run chain so verification failure can be exercised. It
+// round-trips the session through axi's public snapshot API, mutates the
+// record's Value while leaving its Hash untouched, and reloads — so
+// VerifyEvidenceChain recomputes a mismatching hash. No axi internals are
+// touched; the chain is otherwise append-only.
+func (g *kernelGovernor) corruptEvidence(index int) {
+	snap := g.evidence.ToSnapshot()
+	if index < 0 || index >= len(snap.Evidence) {
+		return
+	}
+	snap.Evidence[index].Value = "tampered"
+	reloaded, err := axidomain.SessionFromSnapshot(snap)
+	if err != nil {
+		return
+	}
+	g.evidence = reloaded
+}
+
+// errRunSessionClosed unwinds the in-flight run session executor cleanly when
+// the governor is closed. It is an expected terminal signal, not a fault.
+var errRunSessionClosed = errors.New("governance: run session closed")
+
+// runSessionExecutor is the OrchestratorActionExecutor that holds the run's
+// in-flight axi session. It blocks on reqCh, driving exactly one caps.Invoke
+// per act-state tool call so axi's per-session budget counts run-level tool
+// calls, and unwinds when doneCh closes.
+type runSessionExecutor struct {
+	reqCh  <-chan stepRequest
+	doneCh <-chan struct{}
+}
+
+// ExecuteOrchestrated drives the run session. caps is the per-session
+// CapabilityInvoker whose budget enforcer counts every Invoke across the run.
+func (e *runSessionExecutor) ExecuteOrchestrated(
+	ctx context.Context,
+	_ any,
+	caps axidomain.CapabilityInvoker,
+	_ axidomain.ActionInvoker,
+) (axidomain.ExecutionResult, []axidomain.EvidenceRecord, error) {
+	for {
+		select {
+		case <-e.doneCh:
+			return axidomain.ExecutionResult{Summary: "run session complete"}, nil, nil
+		case <-ctx.Done():
+			return axidomain.ExecutionResult{}, nil, ctx.Err()
+		case req := <-e.reqCh:
+			_, err := caps.Invoke(runStepCapability, req.input)
+			req.respCh <- stepResponse{err: err}
+		}
+	}
+}
+
+// Execute is the synchronous fallback required of OrchestratorActionExecutor
+// implementations. It is unused in the run-session path (an ActionInvoker is
+// always wired by the kernel) but keeps the contract complete.
+func (e *runSessionExecutor) Execute(
+	ctx context.Context,
+	input any,
+	caps axidomain.CapabilityInvoker,
+) (axidomain.ExecutionResult, []axidomain.EvidenceRecord, error) {
+	return e.ExecuteOrchestrated(ctx, input, caps, nil)
+}
+
+// runStepExecutor is the no-op capability behind runStepCapability. Invoking
+// it consumes one MaxCapabilityInvocations slot — that is the only effect
+// that matters; the real tool runs in agent-go after authorization.
+type runStepExecutor struct{}
+
+func (runStepExecutor) Execute(_ context.Context, _ any) (any, error) {
+	return struct{}{}, nil
+}
+
+// runPlugin contributes the run-session action and its step capability. The
+// action has a none effect profile so the run session itself never pauses for
+// approval — per-tool approval is gated separately via the write-external
+// gate action.
+type runPlugin struct{}
+
+func (runPlugin) Contribute() (*axidomain.PluginContribution, error) {
+	stepCap, err := axidomain.NewCapabilityDefinition(
+		runStepCapability,
+		"Counts one act-state tool call against the run budget",
+		axidomain.EmptyContract(),
+		axidomain.EmptyContract(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := stepCap.BindExecutor(runStepExecRef); err != nil {
+		return nil, err
+	}
+
+	req, err := axidomain.NewRequirementSet(axidomain.Requirement{Capability: runStepCapability})
+	if err != nil {
+		return nil, err
+	}
+	action, err := axidomain.NewActionDefinition(
+		runSessionAction,
+		"One agent run as a single axi session enforcing the tool-call budget",
+		axidomain.EmptyContract(),
+		axidomain.EmptyContract(),
+		req,
+		axidomain.EffectProfile{Level: axidomain.EffectNone},
+		axidomain.IdempotencyProfile{IsIdempotent: false},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := action.BindExecutor(runSessionExecRef); err != nil {
+		return nil, err
+	}
+	return axidomain.NewPluginContribution(
+		runPluginID,
+		[]*axidomain.ActionDefinition{action},
+		[]*axidomain.CapabilityDefinition{stepCap},
+	)
+}
+
+// isBudgetExceeded reports whether err is axi's per-session budget-exceeded
+// error raised by CapabilityInvoker.Invoke. axi encodes the limit kind in the
+// message ("execution budget exceeded: max N capability invocations"); it does
+// not yet return a typed sentinel, so a substring match is the available seam.
+func isBudgetExceeded(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "budget exceeded")
+}

--- a/infrastructure/governance/kernel.go
+++ b/infrastructure/governance/kernel.go
@@ -170,35 +170,63 @@ type kernelGovernor struct {
 	evidence *axidomain.ExecutionSession
 
 	mu       sync.Mutex
+	consumed int
 	startErr error
 	runErr   error
 	closed   bool
 }
 
-// Authorize gates a tool: it drives one capability invocation through the
-// in-flight run session so axi's per-session budget counts the call, then —
-// for approval-requiring tools — runs the kernel's effect-gated pause.
+// Authorize gates a tool. Precedence matches the in-process Governors:
+// budget exhaustion is reported before approval. The run-level budget is
+// enforced by the in-flight axi session — each authorized call drives one
+// caps.Invoke, and the (limit+1)th invocation fails natively. The local
+// policy.Budget mirror provides the non-consuming precedence check and keeps
+// BudgetSnapshot in lockstep with axi's session count.
 func (g *kernelGovernor) Authorize(ctx context.Context, req ToolRequest) (Authorization, error) {
 	if g.startErr != nil {
 		return Authorization{}, g.startErr
 	}
 
-	// Run-level budget: one capability invocation against the run session.
-	// axi's enforcer fails the (limit+1)th invocation natively.
+	// Budget precedence: a non-consuming check so an exhausted budget is
+	// reported before (and instead of) prompting for approval.
+	if !g.budget.CanConsume(budgetKey, 1) {
+		return Authorization{Decision: DecisionBudgetExhausted}, nil
+	}
+
+	// Approval gate next, so a denied tool consumes no budget — mirroring the
+	// in-process Governors.
+	approver := ""
+	if req.RequireApproval {
+		if g.approver == nil {
+			return Authorization{}, ErrNoApprover
+		}
+		auth, err := g.gateApproval(ctx, req)
+		if err != nil || auth.Decision != DecisionAllow {
+			return auth, err
+		}
+		approver = auth.Approver
+	}
+
+	// Authoritative consume: one capability invocation against the run
+	// session. axi's enforcer counts it and fails the (limit+1)th natively.
 	if err := g.invokeStep(ctx, req); err != nil {
 		if isBudgetExceeded(err) {
 			return Authorization{Decision: DecisionBudgetExhausted}, nil
 		}
 		return Authorization{}, fmt.Errorf("governance: run session step: %w", err)
 	}
+	g.consumeStep()
 
-	if !req.RequireApproval {
-		return Authorization{Decision: DecisionAllow}, nil
-	}
-	if g.approver == nil {
-		return Authorization{}, ErrNoApprover
-	}
-	return g.gateApproval(ctx, req)
+	return Authorization{Decision: DecisionAllow, Approver: approver}, nil
+}
+
+// consumeStep advances the local budget mirror to track the run session's
+// axi-enforced invocation count.
+func (g *kernelGovernor) consumeStep() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.consumed++
+	_ = g.budget.Consume(budgetKey, 1)
 }
 
 // invokeStep sends one tool call into the in-flight run session and waits for
@@ -263,12 +291,12 @@ func (g *kernelGovernor) gateApproval(ctx context.Context, req ToolRequest) (Aut
 	return Authorization{Decision: DecisionAllow, Approver: resp.Approver}, nil
 }
 
-// Commit accounts a completed tool call: it consumes the local budget mirror
-// (so snapshots agree with the engine's ledger and run results) and appends
-// one EvidenceRecord to the run's single axi-native evidence chain.
+// Commit records a completed tool call's evidence on the run's single
+// axi-native chain. The budget slot was already consumed (authoritatively by
+// axi) at Authorize time — axi gates the call attempt, so Commit does not
+// double-count. It returns the remaining tool-call budget for the ledger.
 func (g *kernelGovernor) Commit(_ context.Context, req ToolRequest, out Outcome) (Commit, error) {
 	if out.Success {
-		_ = g.budget.Consume(budgetKey, 1)
 		g.evidence.AppendEvidence(axidomain.EvidenceRecord{
 			Kind:      "tool_result",
 			Source:    req.ToolName,

--- a/infrastructure/governance/kernel.go
+++ b/infrastructure/governance/kernel.go
@@ -2,6 +2,7 @@ package governance
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -29,16 +30,21 @@ import (
 // action execution. A held session is therefore realised in agent-go (the
 // consumer) rather than added to axi: KernelFactory.Governor starts ONE
 // kernel.Execute(runSessionAction) on a goroutine whose
-// OrchestratorActionExecutor blocks on a channel. Each act-state tool call
-// drives one caps.Invoke through that in-flight session, so axi's budget
-// enforcer counts tool calls across the whole run and fails the (N+1)th
-// natively with the budget error. The run loop stays statekit-driven; only
-// the governed tool gate routes through the kernel session. axi is untouched
-// — no held-session API, preserving its independence.
+// OrchestratorActionExecutor blocks on a channel, scoped to the run ctx. Each
+// SUCCESSFUL act-state tool call drives one caps.Invoke through that in-flight
+// session at Commit time, so axi's budget enforcer counts successful tool
+// calls across the run and fails the (N+1)th natively; a failed or denied tool
+// consumes no slot (parity with the other Governors). The run loop stays
+// statekit-driven; only the governed tool gate routes through the kernel
+// session. axi is untouched — no held-session API, preserving its
+// independence.
 //
 // Evidence: each committed tool call appends one EvidenceRecord to the run's
 // axidomain.ExecutionSession, forming a single tamper-evident chain per run,
-// verifiable via VerifyEvidenceChain.
+// verifiable via VerifyEvidenceChain. The chain survives a human-input pause
+// as ONE continuous physical chain via the public Snapshot/SessionFromSnapshot
+// API (the engine persists the snapshot on the run aggregate and rehydrates on
+// resume).
 //
 // Approval: destructive tools drive the write-external gate action through
 // the kernel (the same primitive AxiFactory uses), gated per call.
@@ -64,6 +70,20 @@ type EvidenceVerifier interface {
 	EvidenceCount() int
 }
 
+// EvidenceSnapshotter serialises the run's evidence chain so it can survive a
+// human-input pause. The engine captures it before a pause and persists it on
+// the run aggregate.
+type EvidenceSnapshotter interface {
+	EvidenceSnapshot() ([]byte, error)
+}
+
+// EvidenceRehydrator restores a run's evidence chain from a snapshot captured
+// before a pause, so the resumed run continues ONE physical chain rather than
+// starting a fresh one.
+type EvidenceRehydrator interface {
+	RehydrateEvidence(data []byte) error
+}
+
 // KernelFactory builds per-run kernel Governors that fully delegate budget,
 // approval, and evidence to axi. Each run gets its own axi.Kernel so the
 // run-level budget maps onto that kernel's per-session ExecutionBudget.
@@ -78,25 +98,36 @@ func NewKernelFactory(approver policy.Approver) (*KernelFactory, error) {
 	return &KernelFactory{approver: approver}, nil
 }
 
-// Governor starts one axi session for the run and returns a Governor bound
-// to it. The session's ExecutionBudget.MaxCapabilityInvocations is taken
-// from the run's tool_calls budget, so axi enforces the run-level count.
-func (f *KernelFactory) Governor(budget *policy.Budget) Governor {
-	limit := budget.Remaining(budgetKey) // -1 when unlimited
+// Governor starts one axi session for the run and returns a Governor bound to
+// it, scoped to ctx so the held session tracks the run's cancellation and
+// MaxDuration. The session's ExecutionBudget.MaxCapabilityInvocations is taken
+// from the run's REMAINING tool_calls budget, so axi enforces the per-segment
+// count; the run-spanning total is enforced by the seeded local mirror that
+// survives a human-input pause.
+func (f *KernelFactory) Governor(ctx context.Context, budget *policy.Budget) Governor {
+	limit := budget.Remaining(budgetKey) // -1 when unlimited, >=0 otherwise
 
 	kernel := axi.New()
-	if limit >= 0 {
+	// axi treats MaxCapabilityInvocations:0 as "no limit", which would make a
+	// zero tool_calls budget paradoxically unlimited. The governor therefore
+	// never delegates a session for a non-positive remaining budget: the
+	// authoritative precedence gate (CanConsume on the local mirror) blocks the
+	// first call in Authorize. For a positive limit, axi enforces the count
+	// within the segment as the authoritative successful-call counter.
+	if limit > 0 {
 		kernel.WithBudget(axi.Budget{MaxCapabilityInvocations: limit})
 	}
 	kernel.RegisterCapabilityExecutor(runStepExecRef, runStepExecutor{})
 	kernel.RegisterActionExecutor(gateExecutorRef, gateExecutor{})
 
 	g := &kernelGovernor{
-		budget:   budget,
-		approver: f.approver,
-		kernel:   kernel,
-		reqCh:    make(chan stepRequest),
-		doneCh:   make(chan struct{}),
+		budget:    budget,
+		limit:     limit,
+		approver:  f.approver,
+		kernel:    kernel,
+		reqCh:     make(chan stepRequest),
+		doneCh:    make(chan struct{}),
+		runExited: make(chan struct{}),
 	}
 
 	// Build the run-session executor that holds the in-flight session and
@@ -125,12 +156,16 @@ func (f *KernelFactory) Governor(budget *policy.Budget) Governor {
 	}
 	g.evidence = session
 
-	// Launch the single in-flight run session. kernel.Execute blocks in the
-	// executor on reqCh until Close signals completion.
+	// Launch the single in-flight run session, scoped to the run's ctx so
+	// cancellation and MaxDuration propagate into the held session. runExited
+	// is closed on EVERY exit path (including an early kernel.Execute error
+	// before the orchestrator loop), so invokeStep never blocks on a vanished
+	// receiver.
 	g.wg.Add(1)
 	go func() {
 		defer g.wg.Done()
-		_, runErr := kernel.Execute(context.Background(), axi.Invocation{Action: runSessionAction})
+		defer close(g.runExited)
+		_, runErr := kernel.Execute(ctx, axi.Invocation{Action: runSessionAction})
 		g.mu.Lock()
 		g.runErr = runErr
 		g.mu.Unlock()
@@ -160,12 +195,19 @@ type stepResponse struct {
 // single per-run chain.
 type kernelGovernor struct {
 	budget   *policy.Budget
+	limit    int // remaining tool_calls at session start; -1 unlimited, 0 none
 	approver policy.Approver
 	kernel   *axi.Kernel
 
-	reqCh  chan stepRequest
+	reqCh chan stepRequest
+	// doneCh is closed by Close to unwind the held session deliberately.
 	doneCh chan struct{}
-	wg     sync.WaitGroup
+	// runExited is closed when the run-session goroutine returns, on EVERY
+	// exit path. invokeStep selects on it so an early goroutine exit (e.g. a
+	// kernel.Execute error before the orchestrator loop) cannot deadlock the
+	// next tool call on a vanished receiver.
+	runExited chan struct{}
+	wg        sync.WaitGroup
 
 	evidence *axidomain.ExecutionSession
 
@@ -177,18 +219,21 @@ type kernelGovernor struct {
 }
 
 // Authorize gates a tool. Precedence matches the in-process Governors:
-// budget exhaustion is reported before approval. The run-level budget is
-// enforced by the in-flight axi session — each authorized call drives one
-// caps.Invoke, and the (limit+1)th invocation fails natively. The local
-// policy.Budget mirror provides the non-consuming precedence check and keeps
-// BudgetSnapshot in lockstep with axi's session count.
+// budget exhaustion is reported before approval. A budget slot is NOT
+// consumed here — consumption happens at Commit, and only on tool SUCCESS, so
+// a failed or denied tool burns no budget (parity with the passthrough and
+// approval-only axi Governors). Authorize performs the non-consuming budget
+// pre-check (the authoritative precedence gate) and the per-call approval
+// gate; the authoritative axi caps.Invoke is deferred to Commit.
 func (g *kernelGovernor) Authorize(ctx context.Context, req ToolRequest) (Authorization, error) {
 	if g.startErr != nil {
 		return Authorization{}, g.startErr
 	}
 
 	// Budget precedence: a non-consuming check so an exhausted budget is
-	// reported before (and instead of) prompting for approval.
+	// reported before (and instead of) prompting for approval. This is the
+	// authoritative gate for a zero/exhausted budget — it never delegates a
+	// session, so axi's "0 == unlimited" semantics can never leak through.
 	if !g.budget.CanConsume(budgetKey, 1) {
 		return Authorization{Decision: DecisionBudgetExhausted}, nil
 	}
@@ -207,16 +252,6 @@ func (g *kernelGovernor) Authorize(ctx context.Context, req ToolRequest) (Author
 		approver = auth.Approver
 	}
 
-	// Authoritative consume: one capability invocation against the run
-	// session. axi's enforcer counts it and fails the (limit+1)th natively.
-	if err := g.invokeStep(ctx, req); err != nil {
-		if isBudgetExceeded(err) {
-			return Authorization{Decision: DecisionBudgetExhausted}, nil
-		}
-		return Authorization{}, fmt.Errorf("governance: run session step: %w", err)
-	}
-	g.consumeStep()
-
 	return Authorization{Decision: DecisionAllow, Approver: approver}, nil
 }
 
@@ -231,13 +266,17 @@ func (g *kernelGovernor) consumeStep() {
 
 // invokeStep sends one tool call into the in-flight run session and waits for
 // axi's budget verdict. It never blocks past the run session's lifetime: once
-// the session is closed (doneCh), it returns errRunSessionClosed instead of
-// deadlocking on a vanished receiver.
+// the session is closed (doneCh) OR the run-session goroutine exits for any
+// reason (runExited, including an early kernel.Execute error before the
+// orchestrator loop), it returns errRunSessionClosed instead of deadlocking on
+// a vanished receiver.
 func (g *kernelGovernor) invokeStep(ctx context.Context, req ToolRequest) error {
 	respCh := make(chan stepResponse, 1)
 	select {
 	case g.reqCh <- stepRequest{input: req.ToolName, respCh: respCh}:
 	case <-g.doneCh:
+		return errRunSessionClosed
+	case <-g.runExited:
 		return errRunSessionClosed
 	case <-ctx.Done():
 		return ctx.Err()
@@ -246,6 +285,8 @@ func (g *kernelGovernor) invokeStep(ctx context.Context, req ToolRequest) error 
 	case resp := <-respCh:
 		return resp.err
 	case <-g.doneCh:
+		return errRunSessionClosed
+	case <-g.runExited:
 		return errRunSessionClosed
 	case <-ctx.Done():
 		return ctx.Err()
@@ -297,24 +338,49 @@ func (g *kernelGovernor) gateApproval(ctx context.Context, req ToolRequest) (Aut
 	return Authorization{Decision: DecisionAllow, Approver: resp.Approver}, nil
 }
 
-// Commit records a completed tool call's evidence on the run's single
-// axi-native chain. The budget slot was already consumed (authoritatively by
-// axi) at Authorize time — axi gates the call attempt, so Commit does not
-// double-count. It returns the remaining tool-call budget for the ledger.
-func (g *kernelGovernor) Commit(_ context.Context, req ToolRequest, out Outcome) (Commit, error) {
-	if out.Success {
-		g.evidence.AppendEvidence(axidomain.EvidenceRecord{
-			Kind:      "tool_result",
-			Source:    req.ToolName,
-			Value:     string(out.Output),
-			Timestamp: time.Now().UnixMilli(),
-		})
+// Commit accounts a completed tool call. A budget slot is consumed only on
+// SUCCESS — matching the passthrough and approval-only axi Governors, so a
+// failed tool burns nothing. On success it drives the authoritative axi
+// caps.Invoke (the only budget-consuming path; axi remains the authoritative
+// count of successful calls), advances the local mirror, and appends one
+// EvidenceRecord to the run's single tamper-evident chain. It returns the
+// remaining tool-call budget for the ledger.
+func (g *kernelGovernor) Commit(ctx context.Context, req ToolRequest, out Outcome) (Commit, error) {
+	if !out.Success {
+		return Commit{Remaining: g.budget.Remaining(budgetKey)}, nil
 	}
+
+	// Authoritative consume: one capability invocation against the run session.
+	// axi's enforcer counts it; the local mirror is advanced in lockstep. If
+	// the held session has gone (Close / early exit), fall back to the local
+	// mirror so accounting still completes.
+	if err := g.invokeStep(ctx, req); err != nil {
+		if isBudgetExceeded(err) {
+			// Should not happen — Authorize's mirror pre-check gates this — but
+			// honour axi's verdict if it disagrees.
+			return Commit{Remaining: g.budget.Remaining(budgetKey)}, policy.ErrBudgetExceeded
+		}
+		if !errors.Is(err, errRunSessionClosed) {
+			return Commit{}, fmt.Errorf("governance: run session step: %w", err)
+		}
+	}
+	g.consumeStep()
+
+	g.mu.Lock()
+	g.evidence.AppendEvidence(axidomain.EvidenceRecord{
+		Kind:      "tool_result",
+		Source:    req.ToolName,
+		Value:     string(out.Output),
+		Timestamp: time.Now().UnixMilli(),
+	})
+	g.mu.Unlock()
+
 	return Commit{Remaining: g.budget.Remaining(budgetKey)}, nil
 }
 
 // BudgetSnapshot returns the run budget's snapshot. The local mirror is kept
-// in lockstep with axi's session budget via invokeStep + Consume.
+// in lockstep with axi's session budget: Commit drives axi's caps.Invoke and
+// advances the mirror together, only on tool success.
 func (g *kernelGovernor) BudgetSnapshot() policy.BudgetSnapshot { return g.budget.Snapshot() }
 
 // OwnsApproval reports true: the kernel owns budget, approval, and evidence.
@@ -322,12 +388,54 @@ func (g *kernelGovernor) OwnsApproval() bool { return true }
 
 // VerifyEvidenceChain validates the run's single evidence chain.
 func (g *kernelGovernor) VerifyEvidenceChain() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	return g.evidence.VerifyEvidenceChain()
 }
 
 // EvidenceCount reports the number of records on the run's evidence chain.
 func (g *kernelGovernor) EvidenceCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	return len(g.evidence.Evidence())
+}
+
+// EvidenceSnapshot serialises the run's evidence chain so it can survive a
+// human-input pause and be rehydrated into the resumed run's governor,
+// keeping ONE continuous physical chain across the pause. It uses axi's public
+// SessionSnapshot API; no internals are touched.
+func (g *kernelGovernor) EvidenceSnapshot() ([]byte, error) {
+	g.mu.Lock()
+	snap := g.evidence.ToSnapshot()
+	g.mu.Unlock()
+	data, err := json.Marshal(snap)
+	if err != nil {
+		return nil, fmt.Errorf("governance: marshal evidence snapshot: %w", err)
+	}
+	return data, nil
+}
+
+// RehydrateEvidence restores the run's evidence chain from a snapshot captured
+// before a human-input pause, so the resumed run continues the SAME hash chain
+// rather than starting a fresh one. Subsequent AppendEvidence calls link onto
+// the rehydrated tail, yielding a single continuous, verifiable chain across
+// the pause.
+func (g *kernelGovernor) RehydrateEvidence(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	var snap axidomain.SessionSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("governance: unmarshal evidence snapshot: %w", err)
+	}
+	session, err := axidomain.SessionFromSnapshot(snap)
+	if err != nil {
+		return fmt.Errorf("governance: rehydrate evidence session: %w", err)
+	}
+	g.mu.Lock()
+	g.evidence = session
+	g.mu.Unlock()
+	return nil
 }
 
 // Close ends the in-flight run session and waits for the goroutine to finish.
@@ -348,29 +456,17 @@ func (g *kernelGovernor) Close() error {
 	g.mu.Lock()
 	runErr := g.runErr
 	g.mu.Unlock()
-	if runErr != nil && !errors.Is(runErr, errRunSessionClosed) {
+	// errRunSessionClosed is the deliberate unwind signal; context
+	// cancellation / deadline are the run's own lifecycle ending (ctx is now
+	// threaded into the held session), not a governance fault. Neither is a
+	// real error worth surfacing from Close.
+	if runErr != nil &&
+		!errors.Is(runErr, errRunSessionClosed) &&
+		!errors.Is(runErr, context.Canceled) &&
+		!errors.Is(runErr, context.DeadlineExceeded) {
 		return runErr
 	}
 	return nil
-}
-
-// corruptEvidence is a test-only hook (see kernel_test.go) that tampers with
-// a record on the run chain so verification failure can be exercised. It
-// round-trips the session through axi's public snapshot API, mutates the
-// record's Value while leaving its Hash untouched, and reloads — so
-// VerifyEvidenceChain recomputes a mismatching hash. No axi internals are
-// touched; the chain is otherwise append-only.
-func (g *kernelGovernor) corruptEvidence(index int) {
-	snap := g.evidence.ToSnapshot()
-	if index < 0 || index >= len(snap.Evidence) {
-		return
-	}
-	snap.Evidence[index].Value = "tampered"
-	reloaded, err := axidomain.SessionFromSnapshot(snap)
-	if err != nil {
-		return
-	}
-	g.evidence = reloaded
 }
 
 // errRunSessionClosed unwinds the in-flight run session executor cleanly when

--- a/infrastructure/governance/kernel_test.go
+++ b/infrastructure/governance/kernel_test.go
@@ -1,0 +1,180 @@
+package governance
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	axidomain "go.klarlabs.de/axi/domain"
+
+	"go.klarlabs.de/agent/domain/policy"
+)
+
+// kernelGov builds a full-delegation Governor for one run with the given
+// tool-call budget and approver, failing the test on construction error.
+func kernelGov(t *testing.T, limit int, approver policy.Approver) (*KernelFactory, Governor) {
+	t.Helper()
+	f, err := NewKernelFactory(approver)
+	if err != nil {
+		t.Fatalf("NewKernelFactory: %v", err)
+	}
+	g := f.Governor(policy.NewBudget(map[string]int{budgetKey: limit}))
+	return f, g
+}
+
+func TestKernel_OwnsApproval(t *testing.T) {
+	f, err := NewKernelFactory(nil)
+	if err != nil {
+		t.Fatalf("NewKernelFactory: %v", err)
+	}
+	if !f.OwnsApproval() {
+		t.Fatal("kernel factory must own approval")
+	}
+}
+
+// A run's tool calls consume ONE axi session budget: the Nth tool call
+// (N = limit+1) exceeds the budget and is denied. Budget is enforced
+// natively by axi across CapabilityInvoker calls within one session.
+func TestKernel_RunBudgetIsOneAxiSession(t *testing.T) {
+	_, g := kernelGov(t, 2, nil)
+	defer closeGov(t, g)
+	ctx := context.Background()
+
+	// First two tool calls authorized and committed (consume the session budget).
+	for i := 0; i < 2; i++ {
+		auth, err := g.Authorize(ctx, ToolRequest{ToolName: "read", RunID: "run-1"})
+		if err != nil {
+			t.Fatalf("Authorize call %d: %v", i+1, err)
+		}
+		if !auth.Allowed() {
+			t.Fatalf("call %d: want allow, got %+v", i+1, auth)
+		}
+		if _, err := g.Commit(ctx, ToolRequest{ToolName: "read"}, Outcome{Success: true, Output: json.RawMessage(`{}`)}); err != nil {
+			t.Fatalf("Commit call %d: %v", i+1, err)
+		}
+	}
+
+	// Third tool call exceeds the run budget — axi's session enforces it.
+	auth, err := g.Authorize(ctx, ToolRequest{ToolName: "read", RunID: "run-1"})
+	if err != nil {
+		t.Fatalf("Authorize call 3: %v", err)
+	}
+	if auth.Decision != DecisionBudgetExhausted {
+		t.Fatalf("call 3: want budget exhausted, got %+v", auth)
+	}
+}
+
+// Approval gating still fires for destructive tools, granted via the kernel.
+func TestKernel_ApprovalGatedGranted(t *testing.T) {
+	_, g := kernelGov(t, 5, policy.NewAutoApprover("ci"))
+	defer closeGov(t, g)
+	auth, err := g.Authorize(context.Background(), ToolRequest{
+		ToolName: "rm", RiskLevel: "high", RequireApproval: true, RunID: "run-1",
+	})
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if !auth.Allowed() || auth.Approver != "ci" {
+		t.Fatalf("want allow by ci, got %+v", auth)
+	}
+}
+
+// Approval gating still fires for destructive tools, denied via the kernel.
+func TestKernel_ApprovalGatedDenied(t *testing.T) {
+	_, g := kernelGov(t, 5, policy.NewDenyApprover("blocked"))
+	defer closeGov(t, g)
+	auth, err := g.Authorize(context.Background(), ToolRequest{
+		ToolName: "rm", RequireApproval: true, RunID: "run-1",
+	})
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if auth.Decision != DecisionDenied || auth.Reason != "blocked" {
+		t.Fatalf("want denied/blocked, got %+v", auth)
+	}
+}
+
+func TestKernel_ApprovalRequiredNoApprover(t *testing.T) {
+	_, g := kernelGov(t, 5, nil)
+	defer closeGov(t, g)
+	_, err := g.Authorize(context.Background(), ToolRequest{ToolName: "rm", RequireApproval: true})
+	if !errors.Is(err, ErrNoApprover) {
+		t.Fatalf("want ErrNoApprover, got %v", err)
+	}
+}
+
+// The run's evidence chain verifies after a sequence of tool calls, and
+// it is a single axi-native chain (one EvidenceRecord per committed call).
+func TestKernel_EvidenceChainVerifies(t *testing.T) {
+	_, g := kernelGov(t, 5, nil)
+	defer closeGov(t, g)
+	ctx := context.Background()
+
+	v, ok := g.(EvidenceVerifier)
+	if !ok {
+		t.Fatalf("kernel governor must expose EvidenceVerifier")
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := g.Authorize(ctx, ToolRequest{ToolName: "read", RunID: "run-1"}); err != nil {
+			t.Fatalf("Authorize %d: %v", i, err)
+		}
+		if _, err := g.Commit(ctx, ToolRequest{ToolName: "read"},
+			Outcome{Success: true, Output: json.RawMessage(`{"i":` + string(rune('0'+i)) + `}`)}); err != nil {
+			t.Fatalf("Commit %d: %v", i, err)
+		}
+	}
+
+	if err := v.VerifyEvidenceChain(); err != nil {
+		t.Fatalf("evidence chain must verify, got: %v", err)
+	}
+	if n := v.EvidenceCount(); n != 3 {
+		t.Fatalf("want 3 evidence records, got %d", n)
+	}
+}
+
+// Evidence corruption fails verification: a tampered record breaks the chain.
+func TestKernel_EvidenceCorruptionFailsVerification(t *testing.T) {
+	_, g := kernelGov(t, 5, nil)
+	defer closeGov(t, g)
+	ctx := context.Background()
+
+	if _, err := g.Authorize(ctx, ToolRequest{ToolName: "read"}); err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if _, err := g.Commit(ctx, ToolRequest{ToolName: "read"}, Outcome{Success: true, Output: json.RawMessage(`{}`)}); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	corrupter, ok := g.(evidenceCorrupter)
+	if !ok {
+		t.Fatalf("test requires evidenceCorrupter test hook")
+	}
+	corrupter.corruptEvidence(0)
+
+	v := g.(EvidenceVerifier)
+	err := v.VerifyEvidenceChain()
+	if err == nil {
+		t.Fatal("expected corrupted evidence chain to fail verification")
+	}
+	var broken *axidomain.ErrChainBroken
+	if !errors.As(err, &broken) {
+		t.Fatalf("want ErrChainBroken, got %T: %v", err, err)
+	}
+}
+
+func closeGov(t *testing.T, g Governor) {
+	t.Helper()
+	if c, ok := g.(interface{ Close() error }); ok {
+		if err := c.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}
+}
+
+// evidenceCorrupter is a test-only hook to tamper with the evidence chain
+// so verification failure can be exercised.
+type evidenceCorrupter interface {
+	corruptEvidence(index int)
+}

--- a/infrastructure/governance/kernel_test.go
+++ b/infrastructure/governance/kernel_test.go
@@ -65,6 +65,30 @@ func TestKernel_RunBudgetIsOneAxiSession(t *testing.T) {
 	}
 }
 
+// axi (not the local mirror) is the authoritative budget enforcer: driving
+// the run session directly past its MaxCapabilityInvocations limit returns
+// axi's native budget-exceeded error from CapabilityInvoker.Invoke.
+func TestKernel_AxiSessionIsAuthoritativeBudgetEnforcer(t *testing.T) {
+	_, g := kernelGov(t, 1, nil)
+	defer closeGov(t, g)
+	kg := g.(*kernelGovernor)
+	ctx := context.Background()
+
+	// First invocation within budget.
+	if err := kg.invokeStep(ctx, ToolRequest{ToolName: "read"}); err != nil {
+		t.Fatalf("step 1 must succeed: %v", err)
+	}
+	// Second invocation exceeds MaxCapabilityInvocations=1 — axi's session
+	// enforcer fails it natively, independent of the local mirror.
+	err := kg.invokeStep(ctx, ToolRequest{ToolName: "read"})
+	if err == nil {
+		t.Fatal("step 2 must be rejected by axi budget enforcer")
+	}
+	if !isBudgetExceeded(err) {
+		t.Fatalf("want axi budget-exceeded, got: %v", err)
+	}
+}
+
 // Approval gating still fires for destructive tools, granted via the kernel.
 func TestKernel_ApprovalGatedGranted(t *testing.T) {
 	_, g := kernelGov(t, 5, policy.NewAutoApprover("ci"))

--- a/infrastructure/governance/kernel_test.go
+++ b/infrastructure/governance/kernel_test.go
@@ -20,8 +20,24 @@ func kernelGov(t *testing.T, limit int, approver policy.Approver) (*KernelFactor
 	if err != nil {
 		t.Fatalf("NewKernelFactory: %v", err)
 	}
-	g := f.Governor(policy.NewBudget(map[string]int{budgetKey: limit}))
+	g := f.Governor(context.Background(), policy.NewBudget(map[string]int{budgetKey: limit}))
 	return f, g
+}
+
+// allowAndCommit authorizes a successful tool call and commits it, advancing
+// both the local mirror and axi's authoritative successful-call count.
+func allowAndCommit(t *testing.T, g Governor, ctx context.Context, tool string) Authorization {
+	t.Helper()
+	auth, err := g.Authorize(ctx, ToolRequest{ToolName: tool, RunID: "run-1"})
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if auth.Allowed() {
+		if _, err := g.Commit(ctx, ToolRequest{ToolName: tool}, Outcome{Success: true, Output: json.RawMessage(`{}`)}); err != nil {
+			t.Fatalf("Commit: %v", err)
+		}
+	}
+	return auth
 }
 
 func TestKernel_OwnsApproval(t *testing.T) {
@@ -87,6 +103,77 @@ func TestKernel_AxiSessionIsAuthoritativeBudgetEnforcer(t *testing.T) {
 	}
 	if !isBudgetExceeded(err) {
 		t.Fatalf("want axi budget-exceeded, got: %v", err)
+	}
+}
+
+// A failed tool call does NOT consume a run-budget slot — parity with the
+// passthrough and approval-only axi Governors, which consume only on success.
+// Under full delegation, the authoritative axi caps.Invoke happens at Commit
+// gated on Outcome.Success, so a failure burns nothing.
+func TestKernel_FailedToolDoesNotConsumeBudget(t *testing.T) {
+	_, g := kernelGov(t, 2, nil)
+	defer closeGov(t, g)
+	ctx := context.Background()
+	req := ToolRequest{ToolName: "write", RunID: "run-1"}
+
+	// Authorize, then the tool fails: Commit with Success:false consumes nothing.
+	auth, err := g.Authorize(ctx, req)
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if !auth.Allowed() {
+		t.Fatalf("want allow, got %+v", auth)
+	}
+	commit, err := g.Commit(ctx, req, Outcome{Success: false})
+	if err != nil {
+		t.Fatalf("Commit(failure): %v", err)
+	}
+	if commit.Remaining != 2 {
+		t.Fatalf("failed tool must not consume budget; remaining=%d want 2", commit.Remaining)
+	}
+
+	// The whole budget remains: two successful calls must still be allowed.
+	for i := 0; i < 2; i++ {
+		if a := allowAndCommit(t, g, ctx, "read"); !a.Allowed() {
+			t.Fatalf("success call %d should be allowed, got %+v", i+1, a)
+		}
+	}
+	// Now exhausted.
+	a, err := g.Authorize(ctx, ToolRequest{ToolName: "read", RunID: "run-1"})
+	if err != nil {
+		t.Fatalf("Authorize after exhaustion: %v", err)
+	}
+	if a.Decision != DecisionBudgetExhausted {
+		t.Fatalf("want budget exhausted after 2 successes, got %+v", a)
+	}
+}
+
+// A successful tool call consumes exactly one slot, matching the other
+// Governors' success-only accounting.
+func TestKernel_SuccessConsumesOneSlot(t *testing.T) {
+	_, g := kernelGov(t, 3, nil)
+	defer closeGov(t, g)
+	ctx := context.Background()
+	allowAndCommit(t, g, ctx, "read")
+	snap := g.BudgetSnapshot()
+	if snap.Remaining[budgetKey] != 2 {
+		t.Fatalf("one success must leave 2; remaining=%d", snap.Remaining[budgetKey])
+	}
+}
+
+// A zero tool_calls budget must allow ZERO tool calls. axi treats
+// MaxCapabilityInvocations:0 as no-limit, so the governor must block the very
+// first call on its own authoritative precedence gate, never delegating an
+// unlimited session.
+func TestKernel_ZeroBudgetAllowsNoToolCalls(t *testing.T) {
+	_, g := kernelGov(t, 0, nil)
+	defer closeGov(t, g)
+	auth, err := g.Authorize(context.Background(), ToolRequest{ToolName: "read", RunID: "run-1"})
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if auth.Decision != DecisionBudgetExhausted {
+		t.Fatalf("zero budget must deny first call, got %+v", auth)
 	}
 }
 
@@ -204,6 +291,152 @@ func TestKernel_AuthorizeAfterCloseDoesNotDeadlock(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("Authorize after Close deadlocked")
+	}
+}
+
+// If the held run session's goroutine exits before Close (e.g. the run ctx is
+// cancelled, or kernel.Execute returns early before the orchestrator loop),
+// invokeStep must not block forever waiting on a vanished receiver. The
+// governor closes runExited on EVERY goroutine exit path, so invokeStep
+// unwinds promptly. Driven here by cancelling the run ctx, which makes the
+// held session return and close runExited without Close being called.
+func TestKernel_EarlyGoroutineExitDoesNotDeadlock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	f, err := NewKernelFactory(nil)
+	if err != nil {
+		t.Fatalf("NewKernelFactory: %v", err)
+	}
+	g := f.Governor(ctx, policy.NewBudget(map[string]int{budgetKey: 5}))
+	kg := g.(*kernelGovernor)
+	defer closeGov(t, g)
+
+	// Cancel the run ctx; the held session's goroutine returns and closes
+	// runExited. Wait for it so the early-exit state is in effect.
+	cancel()
+	select {
+	case <-kg.runExited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run session goroutine did not exit on ctx cancel")
+	}
+
+	// A tool call after the early exit must not deadlock — it unwinds on
+	// runExited (here ctx is also done, but the point is no hang on reqCh).
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = kg.invokeStep(context.Background(), ToolRequest{ToolName: "read"})
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("invokeStep deadlocked after early goroutine exit")
+	}
+}
+
+// The evidence chain is a single continuous physical chain across a
+// human-input pause: a governor rehydrated from a prior segment's snapshot
+// continues the same hash chain, and verification still holds end-to-end.
+func TestKernel_EvidenceRehydratesAcrossPause(t *testing.T) {
+	ctx := context.Background()
+	f, err := NewKernelFactory(nil)
+	if err != nil {
+		t.Fatalf("NewKernelFactory: %v", err)
+	}
+
+	// Segment 1: two successful tool calls, then snapshot (as a pause would).
+	b1 := policy.NewBudget(map[string]int{budgetKey: 5})
+	g1 := f.Governor(ctx, b1)
+	for i := 0; i < 2; i++ {
+		allowAndCommit(t, g1, ctx, "read")
+	}
+	snap, err := g1.(EvidenceSnapshotter).EvidenceSnapshot()
+	if err != nil {
+		t.Fatalf("EvidenceSnapshot: %v", err)
+	}
+	closeGov(t, g1)
+
+	// Segment 2: rehydrate, seed remaining budget, append one more call.
+	b2 := policy.NewBudget(map[string]int{budgetKey: 5})
+	_ = b2.Consume(budgetKey, 2) // seed consumed from segment 1
+	g2 := f.Governor(ctx, b2)
+	if err := g2.(EvidenceRehydrator).RehydrateEvidence(snap); err != nil {
+		t.Fatalf("RehydrateEvidence: %v", err)
+	}
+	allowAndCommit(t, g2, ctx, "read")
+	defer closeGov(t, g2)
+
+	v := g2.(EvidenceVerifier)
+	if err := v.VerifyEvidenceChain(); err != nil {
+		t.Fatalf("continuous chain must verify across pause: %v", err)
+	}
+	if n := v.EvidenceCount(); n != 3 {
+		t.Fatalf("want 3 records on the continuous chain, got %d", n)
+	}
+}
+
+// Budget survives a pause: a governor seeded with the consumed count from a
+// prior segment enforces the run-spanning remainder, not a reset full budget.
+func TestKernel_BudgetSeededAcrossPause(t *testing.T) {
+	ctx := context.Background()
+	f, err := NewKernelFactory(nil)
+	if err != nil {
+		t.Fatalf("NewKernelFactory: %v", err)
+	}
+	// Run-level budget is 2; segment 1 already consumed 2 before the pause.
+	b := policy.NewBudget(map[string]int{budgetKey: 2})
+	_ = b.Consume(budgetKey, 2)
+	g := f.Governor(ctx, b)
+	defer closeGov(t, g)
+
+	auth, err := g.Authorize(ctx, ToolRequest{ToolName: "read", RunID: "run-1"})
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if auth.Decision != DecisionBudgetExhausted {
+		t.Fatalf("seeded-exhausted budget must deny, got %+v (no reset to full)", auth)
+	}
+}
+
+// Two concurrent kernel-governed runs do not interfere: each has its own
+// session, budget, and evidence chain.
+func TestKernel_ConcurrentRunsDoNotInterfere(t *testing.T) {
+	ctx := context.Background()
+	f, err := NewKernelFactory(nil)
+	if err != nil {
+		t.Fatalf("NewKernelFactory: %v", err)
+	}
+	run := func(limit int) error {
+		g := f.Governor(ctx, policy.NewBudget(map[string]int{budgetKey: limit}))
+		defer closeGov(t, g)
+		for i := 0; i < limit; i++ {
+			if a := allowAndCommit(t, g, ctx, "read"); !a.Allowed() {
+				return errors.New("expected allow within budget")
+			}
+		}
+		a, err := g.Authorize(ctx, ToolRequest{ToolName: "read", RunID: "run-1"})
+		if err != nil {
+			return err
+		}
+		if a.Decision != DecisionBudgetExhausted {
+			return errors.New("expected exhaustion at limit")
+		}
+		if v, ok := g.(EvidenceVerifier); ok {
+			if err := v.VerifyEvidenceChain(); err != nil {
+				return err
+			}
+			if v.EvidenceCount() != limit {
+				return errors.New("evidence count mismatch")
+			}
+		}
+		return nil
+	}
+	errCh := make(chan error, 2)
+	go func() { errCh <- run(2) }()
+	go func() { errCh <- run(3) }()
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil {
+			t.Fatalf("concurrent run %d: %v", i, err)
+		}
 	}
 }
 

--- a/infrastructure/governance/kernel_test.go
+++ b/infrastructure/governance/kernel_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	axidomain "go.klarlabs.de/axi/domain"
 
@@ -185,6 +186,24 @@ func TestKernel_EvidenceCorruptionFailsVerification(t *testing.T) {
 	var broken *axidomain.ErrChainBroken
 	if !errors.As(err, &broken) {
 		t.Fatalf("want ErrChainBroken, got %T: %v", err, err)
+	}
+}
+
+// Authorize after Close must not deadlock — it returns a governance fault,
+// never blocking on the vanished run-session receiver.
+func TestKernel_AuthorizeAfterCloseDoesNotDeadlock(t *testing.T) {
+	_, g := kernelGov(t, 5, nil)
+	closeGov(t, g)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = g.Authorize(context.Background(), ToolRequest{ToolName: "read"})
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Authorize after Close deadlocked")
 	}
 }
 

--- a/infrastructure/governance/main_test.go
+++ b/infrastructure/governance/main_test.go
@@ -1,0 +1,14 @@
+package governance
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain installs goleak so a Governor whose held run-session goroutine is
+// never released (an un-Closed full-delegation kernel governor) fails CI
+// instead of silently leaking.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/infrastructure/governance/passthrough.go
+++ b/infrastructure/governance/passthrough.go
@@ -92,8 +92,9 @@ func NewPassthroughFactory(approver policy.Approver) *PassthroughFactory {
 	return &PassthroughFactory{approver: approver}
 }
 
-// Governor returns a Passthrough Governor over the given budget.
-func (f *PassthroughFactory) Governor(budget *policy.Budget) Governor {
+// Governor returns a Passthrough Governor over the given budget. The
+// Passthrough holds no per-run resource, so ctx is unused.
+func (f *PassthroughFactory) Governor(_ context.Context, budget *policy.Budget) Governor {
 	return NewPassthrough(budget, f.approver)
 }
 

--- a/interfaces/api/agent.go
+++ b/interfaces/api/agent.go
@@ -104,6 +104,7 @@ import (
 	"go.klarlabs.de/agent/domain/task"
 	"go.klarlabs.de/agent/domain/telemetry"
 	"go.klarlabs.de/agent/domain/tool"
+	"go.klarlabs.de/agent/infrastructure/governance"
 	inframw "go.klarlabs.de/agent/infrastructure/middleware"
 	"go.klarlabs.de/agent/infrastructure/planner"
 	"go.klarlabs.de/agent/infrastructure/resilience"
@@ -278,6 +279,7 @@ func New(opts ...Option) (*Engine, error) {
 		RunStore:     config.runStore,
 		EventStore:   config.eventStore,
 		TaskContext:  config.taskCtx,
+		Governance:   config.governance,
 	}
 
 	engine, err := application.NewEngine(appConfig)
@@ -374,6 +376,7 @@ type engineConfig struct {
 	runStore    run.Store
 	eventStore  event.Store
 	taskCtx     *task.Context
+	governance  governance.Factory
 }
 
 // Option configures the Engine.
@@ -451,6 +454,21 @@ func WithApprover(a policy.Approver) Option {
 func WithBudgets(budgets map[string]int) Option {
 	return func(c *engineConfig) {
 		c.budgets = budgets
+	}
+}
+
+// WithGovernance selects the governance backend that enforces act-state tool
+// budget, approval, and the evidence trail. When unset, the engine delegates
+// the destructive-tool approval gate to an axi.Kernel (AxiFactory) while the
+// run-level budget stays in agent-go.
+//
+// Use governance.NewKernelFactory(approver) for full delegation — each run
+// executes as one axi session so budget, approval, and evidence are all
+// axi-native. Use governance.NewPassthroughFactory(approver) to keep budget
+// and approval fully in-process (approval via the engine middleware).
+func WithGovernance(f governance.Factory) Option {
+	return func(c *engineConfig) {
+		c.governance = f
 	}
 }
 

--- a/test/kernel_delegation_test.go
+++ b/test/kernel_delegation_test.go
@@ -1,0 +1,218 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"go.klarlabs.de/agent/domain/agent"
+	"go.klarlabs.de/agent/domain/policy"
+	"go.klarlabs.de/agent/domain/tool"
+	"go.klarlabs.de/agent/infrastructure/governance"
+	api "go.klarlabs.de/agent/interfaces/api"
+)
+
+// =============================================================================
+// Full axi delegation (Track F): each agent run executes as ONE axi session,
+// so budget, approval, and evidence all flow through the kernel. These tests
+// drive the engine end-to-end with governance.NewKernelFactory and assert the
+// externally-visible behaviour is preserved.
+// =============================================================================
+
+func kernelFactory(t *testing.T, approver policy.Approver) governance.Factory {
+	t.Helper()
+	f, err := governance.NewKernelFactory(approver)
+	if err != nil {
+		t.Fatalf("NewKernelFactory: %v", err)
+	}
+	return f
+}
+
+// The run's tool calls consume one axi session budget: the (limit+1)th tool
+// call fails the run with the budget error.
+func TestKernelDelegation_RunBudgetExhausts(t *testing.T) {
+	readTool := api.NewToolBuilder("read_file").
+		WithDescription("Reads a file").
+		WithAnnotations(api.Annotations{ReadOnly: true}).
+		WithHandler(func(_ context.Context, _ json.RawMessage) (tool.Result, error) {
+			return tool.Result{Output: json.RawMessage(`{}`)}, nil
+		}).
+		MustBuild()
+
+	registry := api.NewToolRegistry()
+	if err := registry.Register(readTool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	eligibility := api.NewToolEligibility()
+	eligibility.Allow(agent.StateExplore, "read_file")
+
+	scripted := api.NewScriptedPlanner(
+		api.ScriptStep{ExpectState: agent.StateIntake, Decision: api.NewTransitionDecision(agent.StateExplore, "to explore")},
+		api.ScriptStep{ExpectState: agent.StateExplore, Decision: api.NewCallToolDecision("read_file", json.RawMessage(`{}`), "first")},
+		api.ScriptStep{ExpectState: agent.StateExplore, Decision: api.NewCallToolDecision("read_file", json.RawMessage(`{}`), "second")},
+	)
+
+	engine, err := api.New(
+		api.WithRegistry(registry),
+		api.WithPlanner(scripted),
+		api.WithToolEligibility(eligibility),
+		api.WithTransitions(api.DefaultTransitions()),
+		api.WithBudgets(map[string]int{"tool_calls": 1}),
+		api.WithGovernance(kernelFactory(t, nil)),
+		api.WithMaxSteps(10),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = engine.Run(context.Background(), "budget exhausts")
+	if err == nil {
+		t.Fatal("expected budget-exceeded error, got nil")
+	}
+	if !errors.Is(err, policy.ErrBudgetExceeded) {
+		t.Fatalf("expected ErrBudgetExceeded, got: %v", err)
+	}
+}
+
+// The run completes when tool calls stay within the run budget.
+func TestKernelDelegation_RunBudgetWithinLimit(t *testing.T) {
+	readTool := api.NewToolBuilder("read_file").
+		WithDescription("Reads a file").
+		WithAnnotations(api.Annotations{ReadOnly: true}).
+		WithHandler(func(_ context.Context, _ json.RawMessage) (tool.Result, error) {
+			return tool.Result{Output: json.RawMessage(`{}`)}, nil
+		}).
+		MustBuild()
+
+	registry := api.NewToolRegistry()
+	if err := registry.Register(readTool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	eligibility := api.NewToolEligibility()
+	eligibility.Allow(agent.StateExplore, "read_file")
+
+	scripted := api.NewScriptedPlanner(
+		api.ScriptStep{ExpectState: agent.StateIntake, Decision: api.NewTransitionDecision(agent.StateExplore, "to explore")},
+		api.ScriptStep{ExpectState: agent.StateExplore, Decision: api.NewCallToolDecision("read_file", json.RawMessage(`{}`), "first")},
+		api.ScriptStep{ExpectState: agent.StateExplore, Decision: api.NewCallToolDecision("read_file", json.RawMessage(`{}`), "second")},
+		api.ScriptStep{ExpectState: agent.StateExplore, Decision: api.NewTransitionDecision(agent.StateDecide, "to decide")},
+		api.ScriptStep{ExpectState: agent.StateDecide, Decision: api.NewFinishDecision("done", json.RawMessage(`{}`))},
+	)
+
+	engine, err := api.New(
+		api.WithRegistry(registry),
+		api.WithPlanner(scripted),
+		api.WithToolEligibility(eligibility),
+		api.WithTransitions(api.DefaultTransitions()),
+		api.WithBudgets(map[string]int{"tool_calls": 5}),
+		api.WithGovernance(kernelFactory(t, nil)),
+		api.WithMaxSteps(10),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	run, err := engine.Run(context.Background(), "within budget")
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if run.Status != agent.RunStatusCompleted {
+		t.Fatalf("expected completed, got %s", run.Status)
+	}
+}
+
+// The approval gate still fires for destructive tools and lets an approved
+// run complete.
+func TestKernelDelegation_DestructiveToolApproved(t *testing.T) {
+	deleteTool := api.NewToolBuilder("delete_file").
+		WithDescription("Deletes a file").
+		WithAnnotations(api.Annotations{Destructive: true, RiskLevel: api.RiskHigh}).
+		WithHandler(func(_ context.Context, _ json.RawMessage) (tool.Result, error) {
+			return tool.Result{Output: json.RawMessage(`{"deleted": true}`)}, nil
+		}).
+		MustBuild()
+
+	registry := api.NewToolRegistry()
+	if err := registry.Register(deleteTool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	eligibility := api.NewToolEligibility()
+	eligibility.Allow(agent.StateAct, "delete_file")
+
+	scripted := api.NewScriptedPlanner(
+		api.ScriptStep{ExpectState: agent.StateIntake, Decision: api.NewTransitionDecision(agent.StateExplore, "to explore")},
+		api.ScriptStep{ExpectState: agent.StateExplore, Decision: api.NewTransitionDecision(agent.StateDecide, "to decide")},
+		api.ScriptStep{ExpectState: agent.StateDecide, Decision: api.NewTransitionDecision(agent.StateAct, "to act")},
+		api.ScriptStep{ExpectState: agent.StateAct, Decision: api.NewCallToolDecision("delete_file", json.RawMessage(`{}`), "delete")},
+		api.ScriptStep{ExpectState: agent.StateAct, Decision: api.NewTransitionDecision(agent.StateValidate, "to validate")},
+		api.ScriptStep{ExpectState: agent.StateValidate, Decision: api.NewFinishDecision("done", json.RawMessage(`{}`))},
+	)
+
+	engine, err := api.New(
+		api.WithRegistry(registry),
+		api.WithPlanner(scripted),
+		api.WithToolEligibility(eligibility),
+		api.WithTransitions(api.DefaultTransitions()),
+		api.WithApprover(api.NewAutoApprover("kernel-approver")),
+		api.WithGovernance(kernelFactory(t, api.NewAutoApprover("kernel-approver"))),
+		api.WithMaxSteps(20),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	run, err := engine.Run(context.Background(), "approved destructive")
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if run.Status != agent.RunStatusCompleted {
+		t.Fatalf("expected completed, got %s", run.Status)
+	}
+}
+
+// Approval denial blocks a destructive tool and fails the run.
+func TestKernelDelegation_DestructiveToolDenied(t *testing.T) {
+	deleteTool := api.NewToolBuilder("delete_file").
+		WithDescription("Deletes a file").
+		WithAnnotations(api.Annotations{Destructive: true, RiskLevel: api.RiskHigh}).
+		WithHandler(func(_ context.Context, _ json.RawMessage) (tool.Result, error) {
+			return tool.Result{Output: json.RawMessage(`{"deleted": true}`)}, nil
+		}).
+		MustBuild()
+
+	registry := api.NewToolRegistry()
+	if err := registry.Register(deleteTool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	eligibility := api.NewToolEligibility()
+	eligibility.Allow(agent.StateAct, "delete_file")
+
+	scripted := api.NewScriptedPlanner(
+		api.ScriptStep{ExpectState: agent.StateIntake, Decision: api.NewTransitionDecision(agent.StateExplore, "to explore")},
+		api.ScriptStep{ExpectState: agent.StateExplore, Decision: api.NewTransitionDecision(agent.StateDecide, "to decide")},
+		api.ScriptStep{ExpectState: agent.StateDecide, Decision: api.NewTransitionDecision(agent.StateAct, "to act")},
+		api.ScriptStep{ExpectState: agent.StateAct, Decision: api.NewCallToolDecision("delete_file", json.RawMessage(`{}`), "delete")},
+	)
+
+	engine, err := api.New(
+		api.WithRegistry(registry),
+		api.WithPlanner(scripted),
+		api.WithToolEligibility(eligibility),
+		api.WithTransitions(api.DefaultTransitions()),
+		api.WithApprover(api.NewDenyApprover("not allowed")),
+		api.WithGovernance(kernelFactory(t, api.NewDenyApprover("not allowed"))),
+		api.WithMaxSteps(10),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = engine.Run(context.Background(), "denied destructive")
+	if err == nil {
+		t.Fatal("expected approval-denied error, got nil")
+	}
+	if !errors.Is(err, tool.ErrApprovalDenied) {
+		t.Fatalf("expected ErrApprovalDenied, got: %v", err)
+	}
+}

--- a/test/kernel_delegation_test.go
+++ b/test/kernel_delegation_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 
 	"go.klarlabs.de/agent/domain/agent"
+	"go.klarlabs.de/agent/domain/event"
 	"go.klarlabs.de/agent/domain/policy"
 	"go.klarlabs.de/agent/domain/tool"
 	"go.klarlabs.de/agent/infrastructure/governance"
+	"go.klarlabs.de/agent/infrastructure/storage/memory"
 	api "go.klarlabs.de/agent/interfaces/api"
 )
 
@@ -119,6 +121,67 @@ func TestKernelDelegation_RunBudgetWithinLimit(t *testing.T) {
 	}
 	if run.Status != agent.RunStatusCompleted {
 		t.Fatalf("expected completed, got %s", run.Status)
+	}
+}
+
+// Full delegation preserves the existing event types: a budget-exhausted run
+// under the kernel governor still emits TypeBudgetExhausted, mapping axi's
+// BUDGET_EXCEEDED back into agent-go's event surface.
+func TestKernelDelegation_BudgetExhaustedEmitsEvent(t *testing.T) {
+	readTool := api.NewToolBuilder("read_file").
+		WithDescription("Reads a file").
+		WithAnnotations(api.Annotations{ReadOnly: true}).
+		WithHandler(func(_ context.Context, _ json.RawMessage) (tool.Result, error) {
+			return tool.Result{Output: json.RawMessage(`{}`)}, nil
+		}).
+		MustBuild()
+
+	registry := api.NewToolRegistry()
+	if err := registry.Register(readTool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	eligibility := api.NewToolEligibility()
+	eligibility.Allow(agent.StateExplore, "read_file")
+
+	scripted := api.NewScriptedPlanner(
+		api.ScriptStep{ExpectState: agent.StateIntake, Decision: api.NewTransitionDecision(agent.StateExplore, "to explore")},
+		api.ScriptStep{ExpectState: agent.StateExplore, Decision: api.NewCallToolDecision("read_file", json.RawMessage(`{}`), "first")},
+		api.ScriptStep{ExpectState: agent.StateExplore, Decision: api.NewCallToolDecision("read_file", json.RawMessage(`{}`), "second")},
+	)
+
+	store := memory.NewEventStore()
+	engine, err := api.New(
+		api.WithRegistry(registry),
+		api.WithPlanner(scripted),
+		api.WithToolEligibility(eligibility),
+		api.WithTransitions(api.DefaultTransitions()),
+		api.WithBudgets(map[string]int{"tool_calls": 1}),
+		api.WithGovernance(kernelFactory(t, nil)),
+		api.WithEventStore(store),
+		api.WithMaxSteps(10),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	run, runErr := engine.Run(ctx, "budget exhausts")
+	if !errors.Is(runErr, policy.ErrBudgetExceeded) {
+		t.Fatalf("expected ErrBudgetExceeded, got: %v", runErr)
+	}
+
+	events, err := store.LoadEvents(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	var sawBudgetExhausted bool
+	for _, e := range events {
+		if e.Type == event.TypeBudgetExhausted {
+			sawBudgetExhausted = true
+		}
+	}
+	if !sawBudgetExhausted {
+		t.Fatal("expected a budget.exhausted event under full axi delegation")
 	}
 }
 


### PR DESCRIPTION
Completes spec §1: budget AND approval now go through axi. Each agent run executes as ONE in-flight axi session (OrchestratorActionExecutor + CapabilityInvoker) — run-level MaxCapabilityInvocations, the approval gate, and one tamper-evident evidence chain per run, all axi-native. No axi change (corrects the earlier 'needs held-session API' assumption).

KernelFactory is now the DEFAULT governance (AxiFactory/PassthroughFactory still available via WithGovernance). Critic-fixed before merge:
- budget consumed on tool SUCCESS (not authorize) — failed tool doesn't burn a slot (parity with passthrough/axi).
- pause/resume keeps ONE continuous evidence chain (axi Snapshot persisted on the run) + seeds budget from consumed calls — no reset, verified on resume.
- early-goroutine-exit deadlock closed; zero-budget no longer unlimited; run ctx propagated into the held session.
- goleak guards; corruptEvidence moved to test-only + mutex-guarded; axi pinned v1.4.0 + budget-error contract test.

7-state lifecycle + 'side effects only in act' untouched. 52+ pkgs go test -race green, goleak active, golangci 0.

https://claude.ai/code/session_01Cah5LkQHbpxog74NLpujQ9