### PR TITLE
feat(engine): no-progress loop detection

### DIFF
--- a/application/engine.go
+++ b/application/engine.go
@@ -32,25 +32,26 @@ import (
 
 // Engine is the main orchestration service for agent execution.
 type Engine struct {
-	registry     tool.Registry
-	planner      planner.Planner
-	executor     *resilience.Executor
-	artifacts    artifact.Store
-	knowledge    knowledge.Store
-	eligibility  *policy.ToolEligibility
-	transitions  *policy.StateTransitions
-	approver     policy.Approver
-	budgetLimits map[string]int
-	maxSteps     int
-	middleware   *middleware.Registry
-	tracer       telemetry.Tracer
-	meter        telemetry.Meter
-	runStore     run.Store
-	eventStore   event.Store
-	taskCtx      *task.Context
-	govFactory   governance.Factory
-	logger       *logging.Logger
-	clock        clock.Clock
+	registry      tool.Registry
+	planner       planner.Planner
+	executor      *resilience.Executor
+	artifacts     artifact.Store
+	knowledge     knowledge.Store
+	eligibility   *policy.ToolEligibility
+	transitions   *policy.StateTransitions
+	approver      policy.Approver
+	budgetLimits  map[string]int
+	maxSteps      int
+	maxNoProgress int
+	middleware    *middleware.Registry
+	tracer        telemetry.Tracer
+	meter         telemetry.Meter
+	runStore      run.Store
+	eventStore    event.Store
+	taskCtx       *task.Context
+	govFactory    governance.Factory
+	logger        *logging.Logger
+	clock         clock.Clock
 }
 
 // EngineConfig contains configuration for the engine.
@@ -65,12 +66,17 @@ type EngineConfig struct {
 	Approver     policy.Approver
 	BudgetLimits map[string]int
 	MaxSteps     int
-	Middleware   *middleware.Registry
-	Tracer       telemetry.Tracer
-	Meter        telemetry.Meter
-	RunStore     run.Store
-	EventStore   event.Store
-	TaskContext  *task.Context
+	// MaxNoProgress aborts a run after this many consecutive steps that make no
+	// progress — no state change AND no new evidence (e.g. the planner keeps
+	// emitting self-transitions or repeats). This is loop detection: it catches a
+	// stuck agent cheaply, long before MaxSteps. Zero uses the default (6).
+	MaxNoProgress int
+	Middleware    *middleware.Registry
+	Tracer        telemetry.Tracer
+	Meter         telemetry.Meter
+	RunStore      run.Store
+	EventStore    event.Store
+	TaskContext   *task.Context
 	// Governance selects the governance backend (budget + approval +
 	// evidence). When nil, the full-delegation KernelFactory is used: each run
 	// is ONE axi session, so budget, the destructive-tool approval gate, and
@@ -96,25 +102,26 @@ func NewEngine(config EngineConfig) (*Engine, error) {
 	}
 
 	e := &Engine{
-		registry:     config.Registry,
-		planner:      config.Planner,
-		executor:     config.Executor,
-		artifacts:    config.Artifacts,
-		knowledge:    config.Knowledge,
-		eligibility:  config.Eligibility,
-		transitions:  config.Transitions,
-		approver:     config.Approver,
-		budgetLimits: config.BudgetLimits,
-		maxSteps:     config.MaxSteps,
-		middleware:   config.Middleware,
-		tracer:       config.Tracer,
-		meter:        config.Meter,
-		runStore:     config.RunStore,
-		eventStore:   config.EventStore,
-		taskCtx:      config.TaskContext,
-		govFactory:   config.Governance,
-		logger:       config.Logger,
-		clock:        config.Clock,
+		registry:      config.Registry,
+		planner:       config.Planner,
+		executor:      config.Executor,
+		artifacts:     config.Artifacts,
+		knowledge:     config.Knowledge,
+		eligibility:   config.Eligibility,
+		transitions:   config.Transitions,
+		approver:      config.Approver,
+		budgetLimits:  config.BudgetLimits,
+		maxSteps:      config.MaxSteps,
+		maxNoProgress: config.MaxNoProgress,
+		middleware:    config.Middleware,
+		tracer:        config.Tracer,
+		meter:         config.Meter,
+		runStore:      config.RunStore,
+		eventStore:    config.EventStore,
+		taskCtx:       config.TaskContext,
+		govFactory:    config.Governance,
+		logger:        config.Logger,
+		clock:         config.Clock,
 	}
 
 	// Set defaults
@@ -141,6 +148,9 @@ func NewEngine(config EngineConfig) (*Engine, error) {
 	}
 	if e.maxSteps == 0 {
 		e.maxSteps = 100
+	}
+	if e.maxNoProgress == 0 {
+		e.maxNoProgress = 6
 	}
 	if e.govFactory == nil {
 		// Default governance: FULL axi delegation (spec § Changes Required #1,
@@ -293,8 +303,13 @@ func (e *Engine) executeRun(ctx context.Context, runID, goal string, vars map[st
 		Vars: vars,
 	})
 
-	// Execute until terminal state or max steps
+	// Execute until terminal state or max steps. Loop detection: a step is
+	// "productive" if it changes state or adds evidence; consecutive
+	// non-productive steps (self-transitions, repeats) trip maxNoProgress.
 	steps := 0
+	noProgress := 0
+	prevState := r.CurrentState
+	prevEvidence := len(r.Evidence)
 	for !interp.IsTerminal() && steps < e.maxSteps {
 		select {
 		case <-ctx.Done():
@@ -352,6 +367,30 @@ func (e *Engine) executeRun(ctx context.Context, runID, goal string, vars map[st
 
 		// Persist run state after each step
 		e.updateRun(ctx, r)
+
+		// Loop detection: abort when the run makes no progress (no state change
+		// and no new evidence) for maxNoProgress consecutive steps.
+		if r.CurrentState == prevState && len(r.Evidence) == prevEvidence {
+			noProgress++
+			if noProgress >= e.maxNoProgress {
+				msg := fmt.Sprintf("no progress: %d consecutive steps without a state change or new evidence (possible loop)", noProgress)
+				r.FailAt(msg, e.endTime(machineCtx))
+				runLedger.RecordRunFailed(r.CurrentState, msg)
+				e.logger.Error().
+					Add(logging.RunID(runID)).
+					Add(logging.State(r.CurrentState)).
+					Msg("run aborted: no progress (possible loop)")
+				e.publishEvent(ctx, runID, event.TypeRunFailed, event.RunFailedPayload{
+					Error: msg, State: r.CurrentState, Duration: r.Duration(),
+				})
+				e.updateRun(ctx, r)
+				return r, agent.ErrNoProgress
+			}
+		} else {
+			noProgress = 0
+		}
+		prevState = r.CurrentState
+		prevEvidence = len(r.Evidence)
 	}
 
 	if steps >= e.maxSteps && !interp.IsTerminal() {

--- a/domain/agent/errors.go
+++ b/domain/agent/errors.go
@@ -22,6 +22,11 @@ var (
 	// ErrAwaitingHumanInput indicates the run is paused awaiting human input.
 	ErrAwaitingHumanInput = errors.New("run is awaiting human input")
 
+	// ErrNoProgress indicates the run was aborted by loop detection: too many
+	// consecutive steps made no progress (no state change and no new evidence),
+	// e.g. the planner kept emitting self-transitions or repeats.
+	ErrNoProgress = errors.New("run aborted: no progress (possible loop)")
+
 	// ErrNoPendingQuestion indicates no pending question exists for human input.
 	ErrNoPendingQuestion = errors.New("run does not have a pending question")
 

--- a/interfaces/api/agent.go
+++ b/interfaces/api/agent.go
@@ -181,6 +181,11 @@ var (
 	// ErrInvalidHumanInput is returned when the provided input doesn't
 	// match the allowed options for the pending question.
 	ErrInvalidHumanInput = agent.ErrInvalidHumanInput
+
+	// ErrNoProgress is returned when loop detection aborts a run: too many
+	// consecutive steps made no progress (no state change and no new evidence).
+	// Tune the threshold with WithMaxNoProgress.
+	ErrNoProgress = agent.ErrNoProgress
 )
 
 // Re-export knowledge types for RAG capabilities.
@@ -265,25 +270,26 @@ func New(opts ...Option) (*Engine, error) {
 	}
 
 	appConfig := application.EngineConfig{
-		Registry:     config.registry,
-		Planner:      config.planner,
-		Executor:     config.executor,
-		Artifacts:    config.artifacts,
-		Knowledge:    config.knowledge,
-		Eligibility:  config.eligibility,
-		Transitions:  config.transitions,
-		Approver:     config.approver,
-		BudgetLimits: config.budgets,
-		MaxSteps:     config.maxSteps,
-		Middleware:   config.middleware,
-		Tracer:       config.tracer,
-		Meter:        config.meter,
-		RunStore:     config.runStore,
-		EventStore:   config.eventStore,
-		TaskContext:  config.taskCtx,
-		Governance:   config.governance,
-		Logger:       config.logger,
-		Clock:        config.clock,
+		Registry:      config.registry,
+		Planner:       config.planner,
+		Executor:      config.executor,
+		Artifacts:     config.artifacts,
+		Knowledge:     config.knowledge,
+		Eligibility:   config.eligibility,
+		Transitions:   config.transitions,
+		Approver:      config.approver,
+		BudgetLimits:  config.budgets,
+		MaxSteps:      config.maxSteps,
+		MaxNoProgress: config.maxNoProgress,
+		Middleware:    config.middleware,
+		Tracer:        config.tracer,
+		Meter:         config.meter,
+		RunStore:      config.runStore,
+		EventStore:    config.eventStore,
+		TaskContext:   config.taskCtx,
+		Governance:    config.governance,
+		Logger:        config.logger,
+		Clock:         config.clock,
 	}
 
 	engine, err := application.NewEngine(appConfig)
@@ -406,25 +412,26 @@ func (e *Engine) Knowledge() knowledge.Store {
 
 // engineConfig holds configuration for engine creation.
 type engineConfig struct {
-	registry    tool.Registry
-	planner     planner.Planner
-	executor    *resilience.Executor
-	artifacts   artifact.Store
-	knowledge   knowledge.Store
-	eligibility *policy.ToolEligibility
-	transitions *policy.StateTransitions
-	approver    policy.Approver
-	budgets     map[string]int
-	maxSteps    int
-	middleware  *middleware.Registry
-	tracer      telemetry.Tracer
-	meter       telemetry.Meter
-	runStore    run.Store
-	eventStore  event.Store
-	taskCtx     *task.Context
-	governance  governance.Factory
-	logger      *logging.Logger
-	clock       clock.Clock
+	registry      tool.Registry
+	planner       planner.Planner
+	executor      *resilience.Executor
+	artifacts     artifact.Store
+	knowledge     knowledge.Store
+	eligibility   *policy.ToolEligibility
+	transitions   *policy.StateTransitions
+	approver      policy.Approver
+	budgets       map[string]int
+	maxSteps      int
+	maxNoProgress int
+	middleware    *middleware.Registry
+	tracer        telemetry.Tracer
+	meter         telemetry.Meter
+	runStore      run.Store
+	eventStore    event.Store
+	taskCtx       *task.Context
+	governance    governance.Factory
+	logger        *logging.Logger
+	clock         clock.Clock
 }
 
 // Option configures the Engine.
@@ -535,6 +542,15 @@ func WithBudget(name string, limit int) Option {
 func WithMaxSteps(n int) Option {
 	return func(c *engineConfig) {
 		c.maxSteps = n
+	}
+}
+
+// WithMaxNoProgress sets loop detection: a run is aborted after this many
+// consecutive steps that make no progress (no state change and no new
+// evidence). Zero uses the default (6).
+func WithMaxNoProgress(n int) Option {
+	return func(c *engineConfig) {
+		c.maxNoProgress = n
 	}
 }
 

--- a/interfaces/api/loopdetect_test.go
+++ b/interfaces/api/loopdetect_test.go
@@ -1,0 +1,45 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.klarlabs.de/agent/domain/agent"
+	"go.klarlabs.de/agent/infrastructure/planner"
+	api "go.klarlabs.de/agent/interfaces/api"
+)
+
+// selfLoopPlanner always transitions to the current state — a non-productive
+// step (no state change, no evidence) that should trip loop detection.
+type selfLoopPlanner struct{}
+
+func (selfLoopPlanner) Plan(_ context.Context, req planner.PlanRequest) (agent.Decision, error) {
+	return api.NewTransitionDecision(req.CurrentState, "stay"), nil
+}
+
+func TestLoopDetection_AbortsNonProgressingRun(t *testing.T) {
+	// Allow the self-transition so it executes without erroring; the run then
+	// makes no progress and loop detection must abort it.
+	trans := api.NewStateTransitions()
+	trans.Allow(api.StateIntake, api.StateIntake)
+
+	eng, err := api.New(
+		api.WithPlanner(selfLoopPlanner{}),
+		api.WithTransitions(trans),
+		api.WithMaxNoProgress(3),
+		api.WithMaxSteps(100),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	run, err := eng.Run(context.Background(), "spin forever")
+	if !errors.Is(err, api.ErrNoProgress) {
+		t.Fatalf("expected ErrNoProgress, got err=%v", err)
+	}
+	if run == nil || run.Status != api.StatusFailed {
+		t.Fatalf("expected failed run, got %+v", run)
+	}
+	// Aborted by no-progress (3), well before MaxSteps (100).
+}


### PR DESCRIPTION
Aborts a run that makes no progress (no state change + no new evidence) for `maxNoProgress` consecutive steps with `agent.ErrNoProgress` — loop detection at the engine layer (statekit rightly allows self/loop transitions, so the churn judgement lives here). Default 6; tune via `api.WithMaxNoProgress`.

Surfaced building senat-os (Grace) on a real LLM that looped on non-advancing transitions until the token budget tripped. Test included.

https://claude.ai/code/session_01Cah5LkQHbpxog74NLpujQ9