### PR TITLE
feat(planner-llm): surface AllowedTransitions + Feedback in prompt

### DIFF
--- a/contrib/planner-llm/go.mod
+++ b/contrib/planner-llm/go.mod
@@ -1,5 +1,5 @@
 module go.klarlabs.de/agent/contrib/planner-llm
 
-go 1.25.0
+go 1.26.2
 
-require go.klarlabs.de/agent v0.10.0
+require go.klarlabs.de/agent v0.15.0

--- a/contrib/planner-llm/go.sum
+++ b/contrib/planner-llm/go.sum
@@ -1,2 +1,4 @@
 go.klarlabs.de/agent v0.10.0 h1:eCWFU38N6Cyji8GXmA32+llx3QZ40GGKd9rdrXezf6k=
 go.klarlabs.de/agent v0.10.0/go.mod h1:3b4RsqGRjJXhuMh74k0Y8sNUtgC1vaZFf0q0MT2bp0Q=
+go.klarlabs.de/agent v0.15.0 h1:2g7AwPkQuUoLmli/0JlmDGR/mhtPGCsqt8bSpxFp98A=
+go.klarlabs.de/agent v0.15.0/go.mod h1:bv1jLH8B+vHpGLq0HH66L1evUGHpvWMy2wYgmBJn0Lk=

--- a/contrib/planner-llm/prompt.go
+++ b/contrib/planner-llm/prompt.go
@@ -42,6 +42,18 @@ func buildUserMessage(req planner.PlanRequest) string {
 	b.WriteString(string(req.CurrentState))
 	b.WriteString("\n\n")
 
+	// Allowed transitions: the only valid next states. The model must transition
+	// to one of these (never to another state, and never to the current one), so
+	// it does not propose a transition the state machine cannot perform.
+	if len(req.AllowedTransitions) > 0 {
+		b.WriteString("## Allowed Transitions\n")
+		b.WriteString("If you choose to transition, the `to_state` MUST be one of:\n")
+		for _, s := range req.AllowedTransitions {
+			fmt.Fprintf(&b, "- %s\n", s)
+		}
+		b.WriteString("Do not transition to any other state, and do not transition to the current state.\n\n")
+	}
+
 	// Available tools
 	if len(req.ToolDefs) > 0 {
 		b.WriteString("## Available Tools\n")
@@ -67,6 +79,14 @@ func buildUserMessage(req planner.PlanRequest) string {
 		b.WriteString("## Budget Remaining\n")
 		b.WriteString(formatBudgets(req.Budgets))
 		b.WriteString("\n")
+	}
+
+	// One-shot feedback from the engine about the previous step (e.g. a rejected
+	// transition). Placed last so it is the most recent context the model reads.
+	if req.Feedback != "" {
+		b.WriteString("## Important Feedback\n")
+		b.WriteString(req.Feedback)
+		b.WriteString("\n\n")
 	}
 
 	b.WriteString("What is your next decision? Respond with a JSON object.")


### PR DESCRIPTION
Consumes the agent v0.15.0 PlanRequest fields:
- **Allowed Transitions** — constrains the LLM's `to_state` to states the machine can reach, eliminating no-edge silent no-ops (the loop root cause).
- **Important Feedback** — one-shot engine note (e.g. a rejected transition) rendered last so the model self-corrects next step.

Bumps agent dep to v0.15.0. Build + tests green.

https://claude.ai/code/session_01Cah5LkQHbpxog74NLpujQ9