### PR TITLE
fix(ci): run CI on docs-only PRs so required checks can report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ on:
       - 'LICENSE'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
+    # No paths-ignore here: branch protection requires this workflow's status
+    # checks (ci / Lint, Test, Build, Security (nox)), and a docs-only PR that
+    # skips the whole workflow never reports them — so the PR is unmergeable
+    # forever without an admin override. Running CI on docs PRs is cheap (no
+    # code changed → cache hits) and keeps them mergeable; the push trigger
+    # above still skips docs, saving minutes on merges.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Problem
Branch protection on `main` requires:
`ci / Lint`, `ci / Test (ubuntu-latest)`, `ci / Build`, `ci / Security (nox)`

…but `.github/workflows/ci.yml` had `paths-ignore: ["**.md", "docs/**", "LICENSE"]` on the **`pull_request`** trigger. A docs-only PR skips the workflow entirely → the required checks never report → the PR sits at `BLOCKED` forever and can only land with an admin override.

## Fix
Drop `paths-ignore` from the `pull_request` trigger so the workflow always runs and reports its required contexts. The `push`-to-`main` trigger **keeps** its `paths-ignore`, so merging docs changes still skips CI and saves minutes.

Running CI on a docs PR is cheap — no code changed, so build/test caches hit.

## Context
This is a latent trap across the fleet: it just blocked a real dependency-CVE fix in statekit (#93), which needed the same change to land. Mirrors the identical fix already in **warden**, **nox** and **statekit**. Applying it to the remaining affected repos.

Fleet-wide sweep — 8 repos: agent-go, auth-go, axi-go, briefkasten, coverctl, fortify, mcp-go, scout.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom