### PR TITLE
fix(security): harden artifact store paths and IDs, keep Gemini key out of URLs

### DIFF
--- a/contrib/planner-llm/providers/gemini.go
+++ b/contrib/planner-llm/providers/gemini.go
@@ -169,8 +169,13 @@ func (p *GeminiProvider) Complete(ctx context.Context, req plannerllm.Completion
 		body.Tools = []geminiToolDef{{FunctionDeclarations: decls}}
 	}
 
-	url := fmt.Sprintf("%s/models/%s:generateContent?key=%s", p.config.BaseURL, model, p.config.APIKey)
-	respBody, err := doRequest(ctx, "POST", url, nil, body, p.config.Timeout)
+	// The API key travels in a header, never in the query string: a URL carrying
+	// "?key=<secret>" ends up verbatim inside *url.Error on any transport failure
+	// (Go redacts userinfo, never the query) and from there into logs, and it is
+	// also recorded by proxies and server access logs.
+	url := fmt.Sprintf("%s/models/%s:generateContent", p.config.BaseURL, model)
+	headers := map[string]string{"x-goog-api-key": p.config.APIKey}
+	respBody, err := doRequest(ctx, "POST", url, headers, body, p.config.Timeout)
 	if err != nil {
 		return plannerllm.CompletionResponse{}, err
 	}

--- a/contrib/planner-llm/providers/providers.go
+++ b/contrib/planner-llm/providers/providers.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	plannerllm "go.klarlabs.de/agent/contrib/planner-llm"
@@ -45,7 +46,7 @@ func doRequest(ctx context.Context, method, url string, headers map[string]strin
 
 	httpReq, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(payload))
 	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
+		return nil, fmt.Errorf("create request: %w", redactURLError(err))
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -59,7 +60,7 @@ func doRequest(ctx context.Context, method, url string, headers map[string]strin
 		if ctx.Err() != nil {
 			return nil, ErrContextCanceled
 		}
-		return nil, fmt.Errorf("%w: %v", ErrConnectionFailed, err)
+		return nil, fmt.Errorf("%w: %v", ErrConnectionFailed, redactURLError(err))
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
@@ -76,6 +77,45 @@ func doRequest(ctx context.Context, method, url string, headers map[string]strin
 	}
 
 	return respBody, nil
+}
+
+// redactURLError strips credential-bearing parts of the URL from a *url.Error
+// before it is formatted into a message a caller is likely to log.
+//
+// net/url's own redaction covers userinfo only: a *url.Error returned by
+// http.Client.Do renders the full request URL, query string included. Providers
+// should not put secrets in query strings at all (see gemini.go), but transport
+// errors are the one place where a URL escapes into an error string verbatim, so
+// the query is dropped here as well — belt and braces for any future endpoint
+// that carries a token, signature or session ID as a parameter.
+//
+// Errors that are not *url.Error are returned unchanged.
+func redactURLError(err error) error {
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		return err
+	}
+
+	redacted := *urlErr
+	redacted.URL = redactURL(urlErr.URL)
+	return &redacted
+}
+
+// redactURL returns raw with any userinfo and query string removed.
+func redactURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		// Unparseable URLs may still contain a secret; reveal nothing.
+		return "[redacted]"
+	}
+
+	parsed.User = nil
+	if parsed.RawQuery != "" {
+		parsed.RawQuery = "[redacted]"
+	}
+	parsed.Fragment = ""
+
+	return parsed.String()
 }
 
 // resolveModel returns the first non-empty model string.

--- a/contrib/planner-llm/providers/providers_test.go
+++ b/contrib/planner-llm/providers/providers_test.go
@@ -3,9 +3,12 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	plannerllm "go.klarlabs.de/agent/contrib/planner-llm"
@@ -735,5 +738,108 @@ func TestResolveModel(t *testing.T) {
 	}
 	if m := resolveModel("", "", "default"); m != "default" {
 		t.Errorf("expected default, got %q", m)
+	}
+}
+
+// --- API key leakage regression tests ---
+
+const testGeminiKey = "AIzaSy-super-secret-gemini-key"
+
+// TestGemini_SendsAPIKeyAsHeader pins the transport of the credential: the key
+// belongs in a header, not in "?key=", where it is captured by proxy and server
+// access logs and rendered verbatim inside *url.Error on any transport failure.
+func TestGemini_SendsAPIKeyAsHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("x-goog-api-key")
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	p := NewGeminiProvider(GeminiConfig{APIKey: testGeminiKey, BaseURL: srv.URL})
+	if _, err := p.Complete(context.Background(), plannerllm.CompletionRequest{
+		Messages: testMessages(),
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotHeader != testGeminiKey {
+		t.Errorf("x-goog-api-key header = %q, want the configured API key", gotHeader)
+	}
+	if gotQuery != "" {
+		t.Errorf("request query string = %q, want empty: credentials must not travel in the URL", gotQuery)
+	}
+	if strings.Contains(gotQuery, testGeminiKey) {
+		t.Error("API key found in request query string")
+	}
+}
+
+// TestGemini_APIKeyNotInTransportError is the regression test for the leak
+// itself. http.Client.Do returns a *url.Error whose Error() prints the whole
+// request URL — net/url redacts userinfo, never the query — and doRequest
+// formatted that verbatim into the returned error, so a single connection
+// failure put a live API key wherever the caller logged it.
+func TestGemini_APIKeyNotInTransportError(t *testing.T) {
+	t.Parallel()
+
+	// Start and immediately stop a server so the address is closed: Complete
+	// then fails inside the transport, the one path that embeds the URL.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	baseURL := srv.URL
+	srv.Close()
+
+	p := NewGeminiProvider(GeminiConfig{APIKey: testGeminiKey, BaseURL: baseURL, Timeout: 5})
+	_, err := p.Complete(context.Background(), plannerllm.CompletionRequest{
+		Messages: testMessages(),
+	})
+	if err == nil {
+		t.Fatal("expected a transport error against a closed port")
+	}
+	if !errors.Is(err, ErrConnectionFailed) {
+		t.Fatalf("error = %v, want it to wrap ErrConnectionFailed", err)
+	}
+	if strings.Contains(err.Error(), testGeminiKey) {
+		t.Errorf("API key leaked into error string: %v", err)
+	}
+}
+
+// TestRedactURLError covers the second layer: even if some endpoint puts a
+// secret in a query string again, transport errors must not carry it.
+func TestRedactURLError(t *testing.T) {
+	t.Parallel()
+
+	inner := errors.New("connection refused")
+	err := redactURLError(&url.Error{
+		Op:  "Post",
+		URL: "https://user:hunter2@example.com/v1/models/x:generateContent?key=" + testGeminiKey + "&alt=sse#frag",
+		Err: inner,
+	})
+
+	msg := err.Error()
+	for _, secret := range []string{testGeminiKey, "hunter2", "alt=sse", "frag"} {
+		if strings.Contains(msg, secret) {
+			t.Errorf("redactURLError() left %q in %q", secret, msg)
+		}
+	}
+	if !strings.Contains(msg, "example.com/v1/models/x:generateContent") {
+		t.Errorf("redactURLError() should keep the non-secret part of the URL, got %q", msg)
+	}
+	if !errors.Is(err, inner) {
+		t.Error("redactURLError() must preserve the wrapped cause")
+	}
+
+	// Non-URL errors pass through untouched.
+	plain := errors.New("boom")
+	if got := redactURLError(plain); got != plain {
+		t.Errorf("redactURLError(plain) = %v, want the original error", got)
+	}
+
+	// An unparseable URL reveals nothing at all.
+	bad := redactURLError(&url.Error{Op: "Post", URL: "://%%zz?key=" + testGeminiKey, Err: inner})
+	if strings.Contains(bad.Error(), testGeminiKey) {
+		t.Errorf("redactURLError() leaked the key from an unparseable URL: %v", bad)
 	}
 }

--- a/domain/artifact/artifact.go
+++ b/domain/artifact/artifact.go
@@ -71,9 +71,52 @@ func (r Ref) WithMetadata(key, value string) Ref {
 	return r
 }
 
-// IsValid returns true if the reference has a valid ID.
+// MaxIDLength bounds the length of an artifact ID. Filesystem-backed stores use
+// the ID as a single path component, and 255 bytes is the common per-component
+// limit on Linux and macOS.
+const MaxIDLength = 255
+
+// IsValidID reports whether id is a well-formed artifact ID.
+//
+// A valid ID is non-empty, at most MaxIDLength bytes long, is neither "." nor
+// "..", and consists only of ASCII letters, digits, '-', '_' and '.'.
+//
+// The charset is deliberately narrow. Stores use the ID verbatim as a path
+// component (filesystem) or object key (GCS, S3), so path separators, parent
+// directory references and control bytes must never appear in one. A Ref is a
+// plain JSON value that can round-trip through tool output and model-authored
+// input, so an ID arriving at Retrieve/Delete/Exists/Metadata is not necessarily
+// an ID this process generated — validation is the store's contract with its
+// caller, not an assumption it may make.
+//
+// The format accepts every ID the bundled stores emit: the filesystem store's
+// "<unix-nanos>-<random>" and the GCS store's UUIDs.
+func IsValidID(id string) bool {
+	if id == "" || len(id) > MaxIDLength {
+		return false
+	}
+	if id == "." || id == ".." {
+		return false
+	}
+	for i := 0; i < len(id); i++ {
+		c := id[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '-', c == '_', c == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// IsValid returns true if the reference carries a well-formed ID.
+//
+// See IsValidID for the accepted format.
 func (r Ref) IsValid() bool {
-	return r.ID != ""
+	return IsValidID(r.ID)
 }
 
 // String returns a string representation of the reference.

--- a/domain/artifact/artifact_test.go
+++ b/domain/artifact/artifact_test.go
@@ -1,6 +1,7 @@
 package artifact_test
 
 import (
+	"strings"
 	"testing"
 
 	"go.klarlabs.de/agent/domain/artifact"
@@ -336,6 +337,52 @@ func TestDomainErrors(t *testing.T) {
 
 			if tt.err.Error() != tt.msg {
 				t.Errorf("%s.Error() = %s, want %s", tt.name, tt.err.Error(), tt.msg)
+			}
+		})
+	}
+}
+
+// TestIsValidID is a regression test for a Ref.IsValid that only checked for a
+// non-empty ID. Stores use the ID as a path component or object key, so a ref
+// carrying "../../etc" passed validation and escaped the store's base directory.
+func TestIsValidID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		id    string
+		valid bool
+	}{
+		{"generated filesystem ID", "1700000000000000000-a1b2c3d4e5f6g7h8", true},
+		{"uuid as used by the GCS store", "3f2504e0-4f89-11d3-9a0c-0305e82c3301", true},
+		{"simple identifier", "art-123", true},
+		{"underscores and dots", "art_123.v2", true},
+		{"maximum length", strings.Repeat("a", artifact.MaxIDLength), true},
+
+		{"empty", "", false},
+		{"parent directory", "..", false},
+		{"current directory", ".", false},
+		{"relative traversal", "../../etc", false},
+		{"traversal with prefix", "artifacts/../../etc", false},
+		{"absolute path", "/etc/passwd", false},
+		{"nested path", "sub/dir", false},
+		{"windows separator", `sub\dir`, false},
+		{"null byte", "a\x00b", false},
+		{"newline", "a\nb", false},
+		{"space", "a b", false},
+		{"over maximum length", strings.Repeat("a", artifact.MaxIDLength+1), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := artifact.IsValidID(tt.id); got != tt.valid {
+				t.Errorf("artifact.IsValidID(%q) = %v, want %v", tt.id, got, tt.valid)
+			}
+			// Ref.IsValid must delegate to the same rule.
+			if got := (artifact.Ref{ID: tt.id}).IsValid(); got != tt.valid {
+				t.Errorf("Ref{ID: %q}.IsValid() = %v, want %v", tt.id, got, tt.valid)
 			}
 		})
 	}

--- a/infrastructure/storage/filesystem/artifact_store.go
+++ b/infrastructure/storage/filesystem/artifact_store.go
@@ -3,6 +3,7 @@ package filesystem
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -10,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"go.klarlabs.de/agent/domain/artifact"
@@ -36,7 +38,12 @@ func (s *ArtifactStore) Store(ctx context.Context, content io.Reader, opts artif
 	id := generateArtifactID()
 
 	// Create artifact directory with restrictive permissions (G301 fix)
-	artifactPath := s.artifactPath(id)
+	artifactPath, err := s.artifactPath(id)
+	if err != nil {
+		// Unreachable: generateArtifactID only emits IDs that pass validation.
+		// Fail closed rather than trust that invariant.
+		return artifact.Ref{}, err
+	}
 	if err := os.MkdirAll(artifactPath, 0750); err != nil {
 		return artifact.Ref{}, fmt.Errorf("failed to create artifact path: %w", err)
 	}
@@ -115,8 +122,14 @@ func (s *ArtifactStore) Retrieve(_ context.Context, ref artifact.Ref) (io.ReadCl
 		return nil, artifact.ErrInvalidRef
 	}
 
-	contentPath := filepath.Join(s.artifactPath(ref.ID), "content")
-	// #nosec G304 -- path is constructed from validated artifact ref, not user input
+	dir, err := s.artifactPath(ref.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	contentPath := filepath.Join(dir, "content")
+	// #nosec G304 -- ref.ID is caller-supplied; artifactPath validates its format
+	// and confines the result to basePath before it reaches os.Open.
 	file, err := os.Open(contentPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -134,7 +147,11 @@ func (s *ArtifactStore) Delete(_ context.Context, ref artifact.Ref) error {
 		return artifact.ErrInvalidRef
 	}
 
-	artifactPath := s.artifactPath(ref.ID)
+	artifactPath, err := s.artifactPath(ref.ID)
+	if err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(artifactPath); os.IsNotExist(err) {
 		return artifact.ErrArtifactNotFound
 	}
@@ -152,8 +169,13 @@ func (s *ArtifactStore) Exists(_ context.Context, ref artifact.Ref) (bool, error
 		return false, artifact.ErrInvalidRef
 	}
 
-	contentPath := filepath.Join(s.artifactPath(ref.ID), "content")
-	_, err := os.Stat(contentPath)
+	dir, err := s.artifactPath(ref.ID)
+	if err != nil {
+		return false, err
+	}
+
+	contentPath := filepath.Join(dir, "content")
+	_, err = os.Stat(contentPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
@@ -169,8 +191,14 @@ func (s *ArtifactStore) Metadata(_ context.Context, ref artifact.Ref) (artifact.
 		return artifact.Ref{}, artifact.ErrInvalidRef
 	}
 
-	metaPath := filepath.Join(s.artifactPath(ref.ID), "metadata.json")
-	// #nosec G304 -- path is constructed from validated artifact ref, not user input
+	dir, err := s.artifactPath(ref.ID)
+	if err != nil {
+		return artifact.Ref{}, err
+	}
+
+	metaPath := filepath.Join(dir, "metadata.json")
+	// #nosec G304 -- ref.ID is caller-supplied; artifactPath validates its format
+	// and confines the result to basePath before it reaches os.Open.
 	file, err := os.Open(metaPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -188,23 +216,89 @@ func (s *ArtifactStore) Metadata(_ context.Context, ref artifact.Ref) (artifact.
 	return storedRef, nil
 }
 
-// artifactPath returns the directory path for an artifact.
-func (s *ArtifactStore) artifactPath(id string) string {
-	return filepath.Join(s.basePath, id)
+// artifactPath returns the directory path for an artifact, confined to basePath.
+//
+// filepath.Join cleans "../" segments but does not confine: joining basePath with
+// an ID of "../../etc" yields a path outside the store, which Delete would then
+// hand to os.RemoveAll. Artifact refs are caller-supplied on every read and delete
+// path, so the ID is validated and the result is checked before any syscall.
+//
+// Two independent checks run here:
+//
+//  1. The ID must satisfy artifact.IsValidID — no separators, no "..", ASCII only.
+//  2. The cleaned join must remain a strict descendant of filepath.Clean(basePath).
+//
+// Check 2 is unreachable while check 1 holds. It is kept deliberately, so that
+// relaxing the ID format later cannot silently reintroduce a traversal.
+//
+// Neither check follows symlinks: a symlink planted *inside* basePath by a
+// separate process with write access there could still redirect a read. That
+// requires an attacker who already controls the store directory, which is
+// outside this store's threat model.
+func (s *ArtifactStore) artifactPath(id string) (string, error) {
+	if !artifact.IsValidID(id) {
+		return "", artifact.ErrInvalidRef
+	}
+	return confineToBase(s.basePath, id)
 }
 
-// generateArtifactID creates a unique artifact ID.
+// confineToBase joins id under base and rejects any result that is not a strict
+// descendant of base. It is kept separate from ID validation so that each layer
+// can be exercised on its own.
+func confineToBase(base, id string) (string, error) {
+	cleanBase := filepath.Clean(base)
+	joined := filepath.Clean(filepath.Join(cleanBase, id))
+	if !strings.HasPrefix(joined, cleanBase+string(filepath.Separator)) {
+		return "", artifact.ErrInvalidRef
+	}
+	return joined, nil
+}
+
+// idRandomLength is the number of random characters appended to an artifact ID.
+// 16 characters over a 36-symbol alphabet is roughly 82 bits of entropy.
+const idRandomLength = 16
+
+// generateArtifactID creates a unique, unpredictable artifact ID.
+//
+// The Unix-nanosecond prefix keeps IDs roughly sortable by creation time; the
+// suffix — not the prefix — is what makes an ID unguessable.
 func generateArtifactID() string {
-	return fmt.Sprintf("%d-%s", time.Now().UnixNano(), randomString(8))
+	return fmt.Sprintf("%d-%s", time.Now().UnixNano(), randomString(idRandomLength))
 }
 
-// randomString generates a random alphanumeric string.
+// randomString generates a cryptographically random alphanumeric string of
+// length n, drawn uniformly from [a-z0-9].
+//
+// The alphabet has 36 symbols, which does not divide 256, so bytes are rejection
+// sampled rather than reduced modulo 36: taking the remainder directly would make
+// the first four symbols ~14% more likely than the rest.
+//
+// This function does not return an error. crypto/rand.Read is documented never to
+// fail — since Go 1.24 the runtime treats an unavailable system CSPRNG as fatal —
+// so the only way to reach the panic below would be a broken rand.Reader override.
+// Panicking is deliberate: an artifact ID that silently fell back to a weak source
+// would be predictable, which is the bug this replaced.
 func randomString(n int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = charset[time.Now().UnixNano()%int64(len(charset))]
-		time.Sleep(time.Nanosecond) // Ensure uniqueness
+	// Largest multiple of len(charset) that fits in a byte; higher values are
+	// discarded to keep the distribution uniform.
+	const limit = 256 - (256 % len(charset)) // 252
+
+	out := make([]byte, 0, n)
+	buf := make([]byte, n)
+	for len(out) < n {
+		if _, err := rand.Read(buf); err != nil {
+			panic("filesystem: crypto/rand unavailable: " + err.Error())
+		}
+		for _, b := range buf {
+			if int(b) >= limit {
+				continue // biased sample, draw again
+			}
+			out = append(out, charset[int(b)%len(charset)])
+			if len(out) == n {
+				break
+			}
+		}
 	}
-	return string(b)
+	return string(out)
 }

--- a/infrastructure/storage/filesystem/artifact_store_test.go
+++ b/infrastructure/storage/filesystem/artifact_store_test.go
@@ -658,3 +658,181 @@ func TestRandomString(t *testing.T) {
 		}
 	}
 }
+
+// TestArtifactStore_RejectsPathTraversal is a regression test for a path
+// traversal in the four methods that take a caller-supplied ref. They gated on
+// Ref.IsValid(), which only checked for a non-empty ID, and then handed the ID
+// to filepath.Join — which cleans "../" but does not confine. Before the fix,
+// Retrieve/Exists/Metadata read files outside basePath and Delete handed the
+// escaped path to os.RemoveAll.
+func TestArtifactStore_RejectsPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	// root/
+	//   base/     <- the artifact store
+	//   outside/  <- must never be read or removed
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	outside := filepath.Join(root, "outside")
+	if err := os.MkdirAll(outside, 0750); err != nil {
+		t.Fatal(err)
+	}
+	// Shaped like a real artifact directory so that, without the fix, every one
+	// of the four methods succeeds rather than merely erroring differently.
+	victims := map[string]string{
+		"secret.txt":    "top secret",
+		"content":       "top secret",
+		"metadata.json": `{"id":"escaped"}`,
+	}
+	for name, data := range victims {
+		if err := os.WriteFile(filepath.Join(outside, name), []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	store, err := NewArtifactStore(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	hostileIDs := []string{
+		"../outside",
+		"../../base/../outside",
+		"..",
+		"../",
+		"./../outside",
+		outside, // absolute path
+		"sub/dir",
+		"nul\x00byte",
+		strings.Repeat("a", 4096),
+	}
+
+	for _, id := range hostileIDs {
+		ref := artifact.NewRef(id)
+
+		if _, err := store.Retrieve(ctx, ref); err != artifact.ErrInvalidRef {
+			t.Errorf("Retrieve(%q) error = %v, want ErrInvalidRef", id, err)
+		}
+		if _, err := store.Exists(ctx, ref); err != artifact.ErrInvalidRef {
+			t.Errorf("Exists(%q) error = %v, want ErrInvalidRef", id, err)
+		}
+		if _, err := store.Metadata(ctx, ref); err != artifact.ErrInvalidRef {
+			t.Errorf("Metadata(%q) error = %v, want ErrInvalidRef", id, err)
+		}
+		if err := store.Delete(ctx, ref); err != artifact.ErrInvalidRef {
+			t.Errorf("Delete(%q) error = %v, want ErrInvalidRef", id, err)
+		}
+	}
+
+	// Nothing outside the store may have been touched.
+	for name := range victims {
+		if _, err := os.Stat(filepath.Join(outside, name)); err != nil {
+			t.Errorf("file outside basePath was affected: %v", err)
+		}
+	}
+}
+
+// TestConfineToBase exercises the confinement layer on its own, with IDs that
+// artifact.IsValidID already rejects. The two checks are deliberately redundant;
+// this test fails if the confinement is dropped in favour of validation alone.
+func TestConfineToBase(t *testing.T) {
+	t.Parallel()
+
+	base := "/srv/artifacts"
+
+	escapes := []string{"..", "../outside", "sub/../../outside", "../artifacts-evil", "."}
+	for _, id := range escapes {
+		if got, err := confineToBase(base, id); err != artifact.ErrInvalidRef {
+			t.Errorf("confineToBase(%q, %q) = %q, %v; want ErrInvalidRef", base, id, got, err)
+		}
+	}
+
+	id := "1700000000000000000-abcdefgh"
+	got, err := confineToBase(base, id)
+	if err != nil {
+		t.Fatalf("confineToBase(%q) error = %v", id, err)
+	}
+	if want := filepath.Join(base, id); got != want {
+		t.Errorf("confineToBase(%q) = %q, want %q", id, got, want)
+	}
+}
+
+// TestRandomString_NotDerivableFromClock is a regression test for an ID
+// generator that filled every character from time.Now().UnixNano()%36 with a
+// 1ns sleep between characters. Because the clock advances by a near-constant
+// amount per iteration, the output collapsed onto a handful of symbols: a
+// measured 2000 samples yielded only 649 distinct strings drawn from 9 of the
+// 36 alphabet characters. With a CSPRNG both counts are pinned by probability,
+// not by scheduling.
+func TestRandomString_NotDerivableFromClock(t *testing.T) {
+	t.Parallel()
+
+	const (
+		samples = 2000
+		length  = 8
+		charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	)
+
+	seen := make(map[string]struct{}, samples)
+	chars := make(map[byte]struct{}, len(charset))
+	for i := 0; i < samples; i++ {
+		s := randomString(length)
+		if len(s) != length {
+			t.Fatalf("randomString(%d) length = %d", length, len(s))
+		}
+		seen[s] = struct{}{}
+		for j := 0; j < len(s); j++ {
+			if !strings.ContainsRune(charset, rune(s[j])) {
+				t.Fatalf("randomString() produced invalid character %q", s[j])
+			}
+			chars[s[j]] = struct{}{}
+		}
+	}
+
+	// 2000 draws from 36^8 (~2.8e12) values: the chance of even one collision is
+	// under one in a million, so any repeat means the source is not random.
+	if len(seen) != samples {
+		t.Errorf("randomString() produced %d distinct values out of %d samples; "+
+			"output is not cryptographically random", len(seen), samples)
+	}
+
+	// 16000 characters over a 36-symbol alphabet: the chance of missing any one
+	// symbol is ~36*(35/36)^16000, i.e. astronomically small.
+	if len(chars) != len(charset) {
+		t.Errorf("randomString() only ever emitted %d of %d alphabet characters; "+
+			"output is clock-derived, not random", len(chars), len(charset))
+	}
+}
+
+// TestGenerateArtifactID_UnpredictableSuffix asserts the property that matters
+// for path safety: knowing when an artifact was written must not be enough to
+// reconstruct its ID. The timestamp prefix is guessable by design, so the check
+// is on the random suffix alone.
+func TestGenerateArtifactID_UnpredictableSuffix(t *testing.T) {
+	t.Parallel()
+
+	const samples = 1000
+
+	suffixes := make(map[string]struct{}, samples)
+	for i := 0; i < samples; i++ {
+		id := generateArtifactID()
+		if !artifact.IsValidID(id) {
+			t.Fatalf("generateArtifactID() = %q, which artifact.IsValidID rejects", id)
+		}
+		idx := strings.LastIndex(id, "-")
+		if idx < 0 {
+			t.Fatalf("generateArtifactID() = %q, want a <nanos>-<random> shape", id)
+		}
+		suffix := id[idx+1:]
+		if len(suffix) != idRandomLength {
+			t.Fatalf("suffix %q length = %d, want %d", suffix, len(suffix), idRandomLength)
+		}
+		suffixes[suffix] = struct{}{}
+	}
+
+	if len(suffixes) != samples {
+		t.Errorf("generateArtifactID() produced %d distinct suffixes out of %d; "+
+			"IDs are predictable from the clock", len(suffixes), samples)
+	}
+}


### PR DESCRIPTION
Three security fixes found during an audit of `agent-go`. **Two of them were not reported by any scanner** — they were found by reading the code around an unrelated false-positive finding.

| # | Issue | Severity | Scanner-flagged? |
|---|---|---|---|
| 1 | Artifact IDs derived from the wall clock, not a CSPRNG | HIGH | **No** |
| 2 | Artifact store joins an unvalidated caller-supplied ID into a filesystem path | HIGH | **No** |
| 3 | Gemini API key in the URL query string leaks into error strings | MEDIUM | Yes |

---

## Fix 1 — `randomString` is not random

`infrastructure/storage/filesystem/artifact_store.go`

```go
b[i] = charset[time.Now().UnixNano()%int64(len(charset))]
time.Sleep(time.Nanosecond) // Ensure uniqueness
```

Every character of every artifact ID — and therefore every on-disk artifact path — came from the wall clock. The `time.Sleep(time.Nanosecond)` cannot provide the claimed uniqueness: it rounds up to scheduler granularity (~µs) and costs ~10µs per ID. Because the clock advances by a near-constant amount per iteration, the output collapses. Measured over 2000 samples of the old function:

* **649 distinct strings out of 2000**
* drawn from only **9 of the 36** alphabet characters

Collisions were masked by the `UnixNano` prefix in `generateArtifactID`, so the real defect is **predictability**: someone who knows roughly when an artifact was written can reconstruct its ID, and hence its path, from a tiny search space. The name `randomString` also invited reuse as a token generator.

**Fixed** with `crypto/rand` plus rejection sampling (36 does not divide 256, so a plain modulo would skew the first four symbols by ~14%). The sleep is gone; the random suffix is now 16 characters (~82 bits). The error-free signature is kept deliberately — `crypto/rand.Read` is documented never to fail, and the function panics rather than silently degrading to a weak source.

## Fix 2 — unvalidated ref ID joined into a filesystem path

`infrastructure/storage/filesystem/artifact_store.go`, `domain/artifact/artifact.go`

```go
func (r Ref) IsValid() bool { return r.ID != "" }
func (s *ArtifactStore) artifactPath(id string) string { return filepath.Join(s.basePath, id) }
```

`Retrieve`, `Delete`, `Exists` and `Metadata` gated only on `IsValid()` (non-empty), then joined the caller's `ref.ID` under `basePath`. `filepath.Join` cleans `../` but does **not** confine. Confirmed against the reverted code: with `ref.ID = "../outside"`, `Retrieve`/`Exists`/`Metadata` returned files from outside `basePath` and `Delete` handed the escaped path to `os.RemoveAll`, deleting a directory the store does not own.

The `#nosec G304 -- path is constructed from validated artifact ref, not user input` annotations were correct for `Store` (ID generated internally) and **wrong** for the four methods where the ref comes from the caller.

**Honest scoping:** I did **not** trace a caller that feeds an attacker-controlled `ref.ID` into these methods, and this PR does not claim a live exploit. A `Ref` is a plain JSON value, so in an agent framework it can plausibly round-trip through tool output and model-authored input — but "plausibly" is where the evidence stops. What this PR does is make the code satisfy the contract the `#nosec` comment already asserted and that every caller is entitled to rely on. The store should be safe against a hostile ID whether or not one can reach it today.

**Fixed in two deliberately redundant layers:**

1. `artifact.IsValidID` — an ID must be `[A-Za-z0-9._-]`, at most 255 bytes, and never `.` or `..`. `Ref.IsValid` delegates to it. The format accepts every ID the bundled stores emit, including the GCS store's UUIDs, so no existing store or test changes behaviour.
2. `artifactPath` confines independently: the cleaned join must remain a strict descendant of `filepath.Clean(basePath)`. This is unreachable while layer 1 holds — it is kept so that relaxing the ID format later cannot silently reintroduce the traversal, and split into `confineToBase` so it can be tested on its own.

The `#nosec` justifications were rewritten to state what actually holds.

**Considered and not done:** `os.Root` (Go 1.24+) would additionally close symlink redirection — a symlink planted *inside* `basePath` by another process can still redirect a read. That requires an attacker who already controls the store directory, and adopting `os.Root` means restructuring all five methods around root-relative names. Noted in the code comment rather than done here.

## Fix 3 — Gemini API key in URL query string

`contrib/planner-llm/providers/gemini.go`, `contrib/planner-llm/providers/providers.go`

The provider built `...:generateContent?key=<APIKey>`. When `http.Client.Do` fails it returns a `*url.Error` whose `Error()` prints the whole request URL — Go's `stripPassword` redacts userinfo and never the query — and `doRequest` formatted that verbatim via `fmt.Errorf("%w: %v", ErrConnectionFailed, err)`. One connection failure put a live API key wherever the caller logs errors. Keys in query strings are also captured by proxy and server access logs regardless of any error.

**Fixed** by sending `x-goog-api-key` as a header (matching how the OpenAI, Anthropic and Cohere providers here already authenticate) and dropping `?key=`; plus `redactURLError`, which strips userinfo, query and fragment from `*url.Error` in the transport-error path so a future endpoint carrying a token or signature as a parameter cannot reopen the leak.

---

## Regression tests

Every test below was **verified to bite**: the fix was temporarily reverted, the test was confirmed to fail, and the fix restored.

| Test | Failure with the fix reverted |
|---|---|
| `TestRandomString_NotDerivableFromClock` | `649 distinct values out of 2000`; `only ever emitted 9 of 36 alphabet characters` |
| `TestGenerateArtifactID_UnpredictableSuffix` | `398 distinct suffixes out of 1000` |
| `TestArtifactStore_RejectsPathTraversal` | `Retrieve("../outside") error = <nil>` — read a file outside `basePath`; `Delete` likewise succeeded |
| `TestConfineToBase` | `confineToBase("/srv/artifacts", "../outside") = "/srv/outside", <nil>` |
| `TestIsValidID` | `IsValidID("../../etc") = true, want false` (+ separators, absolute paths, NUL, over-length) |
| `TestGemini_SendsAPIKeyAsHeader` | `request query string = "key=AIzaSy-super-secret-gemini-key"` |
| `TestGemini_APIKeyNotInTransportError` | `API key leaked into error string: connection failed: Post "http://127.0.0.1:60168/...?key=AIzaSy-super-secret-gemini-key"` |
| `TestRedactURLError` | asserts userinfo/query/fragment stripped, cause preserved, unparseable URLs fully redacted |

## Verification

* `GOWORK=off go build ./...`, `go vet ./...`, `go test ./... -count=1` — clean in the root module and in `contrib/planner-llm`.
* `contrib/storage-gcs` (which `replace`s the root module) builds and tests clean, confirming the tightened `IsValid` does not reject UUID-shaped IDs.
* `gofmt -l` clean.
* `golangci-lint v2.12.2`: **0 issues** for `domain/artifact` and `infrastructure/storage/filesystem`. `contrib/planner-llm` reports 6 issues — byte-identical to `origin/main` before this branch, so nothing new was introduced.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom
