### PR TITLE
fix(security): declare the weak-hash call sites as non-cryptographic

### DIFF
--- a/contrib/pack-crypto/crypto.go
+++ b/contrib/pack-crypto/crypto.go
@@ -98,9 +98,9 @@ func (p *cryptoPack) hashTool() tool.Tool {
 			var h hash.Hash
 			switch algorithm {
 			case "md5":
-				h = md5.New() // #nosec G401 -- MD5 is used for checksum/fingerprinting purposes, not for security
+				h = md5.New() // nox:ignore CRYPTO-001 -- MD5 is used for checksum/fingerprinting purposes, not for security; #nosec G401 -- MD5 is used for checksum/fingerprinting purposes, not for security
 			case "sha1":
-				h = sha1.New() // #nosec G401 -- SHA1 is used for checksum/fingerprinting purposes, not for security
+				h = sha1.New() // nox:ignore CRYPTO-001 -- SHA1 is used for checksum/fingerprinting purposes, not for security; #nosec G401 -- SHA1 is used for checksum/fingerprinting purposes, not for security
 			case "sha256":
 				h = sha256.New()
 			case "sha512":
@@ -165,9 +165,9 @@ func (p *cryptoPack) hashFileTool() tool.Tool {
 			var h hash.Hash
 			switch algorithm {
 			case "md5":
-				h = md5.New() // #nosec G401 -- MD5 is used for checksum/fingerprinting purposes, not for security
+				h = md5.New() // nox:ignore CRYPTO-001 -- MD5 is used for checksum/fingerprinting purposes, not for security; #nosec G401 -- MD5 is used for checksum/fingerprinting purposes, not for security
 			case "sha1":
-				h = sha1.New() // #nosec G401 -- SHA1 is used for checksum/fingerprinting purposes, not for security
+				h = sha1.New() // nox:ignore CRYPTO-001 -- SHA1 is used for checksum/fingerprinting purposes, not for security; #nosec G401 -- SHA1 is used for checksum/fingerprinting purposes, not for security
 			case "sha256":
 				h = sha256.New()
 			case "sha512":
@@ -859,9 +859,9 @@ func (p *cryptoPack) checksumTool() tool.Tool {
 				var h hash.Hash
 				switch algorithm {
 				case "md5":
-					h = md5.New() // #nosec G401 -- MD5 is used for checksum/fingerprinting purposes, not for security
+					h = md5.New() // nox:ignore CRYPTO-001 -- MD5 is used for checksum/fingerprinting purposes, not for security; #nosec G401 -- MD5 is used for checksum/fingerprinting purposes, not for security
 				case "sha1":
-					h = sha1.New() // #nosec G401 -- SHA1 is used for checksum/fingerprinting purposes, not for security
+					h = sha1.New() // nox:ignore CRYPTO-001 -- SHA1 is used for checksum/fingerprinting purposes, not for security; #nosec G401 -- SHA1 is used for checksum/fingerprinting purposes, not for security
 				case "sha256":
 					h = sha256.New()
 				case "sha512":
@@ -924,9 +924,9 @@ func (p *cryptoPack) verifyChecksumTool() tool.Tool {
 			var h hash.Hash
 			switch algorithm {
 			case "md5":
-				h = md5.New() // #nosec G401 -- MD5 is used for checksum/fingerprinting purposes, not for security
+				h = md5.New() // nox:ignore CRYPTO-001 -- MD5 is used for checksum/fingerprinting purposes, not for security; #nosec G401 -- MD5 is used for checksum/fingerprinting purposes, not for security
 			case "sha1":
-				h = sha1.New() // #nosec G401 -- SHA1 is used for checksum/fingerprinting purposes, not for security
+				h = sha1.New() // nox:ignore CRYPTO-001 -- SHA1 is used for checksum/fingerprinting purposes, not for security; #nosec G401 -- SHA1 is used for checksum/fingerprinting purposes, not for security
 			case "sha256":
 				h = sha256.New()
 			case "sha512":

--- a/contrib/pack-fileops/fileops.go
+++ b/contrib/pack-fileops/fileops.go
@@ -1076,7 +1076,7 @@ func fileopsChecksum(baseDir string) tool.Tool {
 			var h hash.Hash
 			switch algorithm {
 			case "md5":
-				h = md5.New() // #nosec G401 -- MD5 used for non-security checksum only
+				h = md5.New() // nox:ignore CRYPTO-001 -- MD5 used for non-security checksum only; #nosec G401 -- MD5 used for non-security checksum only
 			case "sha256":
 				h = sha256.New()
 			case "sha512":

--- a/contrib/pack-hash/hash.go
+++ b/contrib/pack-hash/hash.go
@@ -62,7 +62,7 @@ func md5Tool() tool.Tool {
 				data = params.Bytes
 			}
 
-			h := md5.Sum(data) // #nosec G401 -- MD5 provided for checksum/fingerprinting, not cryptographic security
+			h := md5.Sum(data) // nox:ignore CRYPTO-001 -- MD5 provided for checksum/fingerprinting, not cryptographic security; #nosec G401 -- MD5 provided for checksum/fingerprinting, not cryptographic security
 			hashHex := hex.EncodeToString(h[:])
 			hashB64 := base64.StdEncoding.EncodeToString(h[:])
 
@@ -96,7 +96,7 @@ func sha1Tool() tool.Tool {
 				data = params.Bytes
 			}
 
-			h := sha1.Sum(data) // #nosec G401 -- SHA1 provided for checksum/fingerprinting, not cryptographic security
+			h := sha1.Sum(data) // nox:ignore CRYPTO-001 -- SHA1 provided for checksum/fingerprinting, not cryptographic security; #nosec G401 -- SHA1 provided for checksum/fingerprinting, not cryptographic security
 			hashHex := hex.EncodeToString(h[:])
 			hashB64 := base64.StdEncoding.EncodeToString(h[:])
 
@@ -275,8 +275,8 @@ func multiTool() tool.Tool {
 
 			data := []byte(params.Text)
 
-			md5Sum := md5.Sum(data)   // #nosec G401 -- MD5 provided for checksum/fingerprinting, not cryptographic security
-			sha1Sum := sha1.Sum(data) // #nosec G401 -- SHA1 provided for checksum/fingerprinting, not cryptographic security
+			md5Sum := md5.Sum(data)   // nox:ignore CRYPTO-001 -- MD5 provided for checksum/fingerprinting, not cryptographic security; #nosec G401 -- MD5 provided for checksum/fingerprinting, not cryptographic security
+			sha1Sum := sha1.Sum(data) // nox:ignore CRYPTO-001 -- SHA1 provided for checksum/fingerprinting, not cryptographic security; #nosec G401 -- SHA1 provided for checksum/fingerprinting, not cryptographic security
 			sha256Sum := sha256.Sum256(data)
 			sha512Sum := sha512.Sum512(data)
 			crc32Sum := crc32.ChecksumIEEE(data)
@@ -315,10 +315,10 @@ func verifyTool() tool.Tool {
 
 			switch strings.ToLower(params.Algorithm) {
 			case "md5":
-				h := md5.Sum(data) // #nosec G401 -- MD5 provided for checksum/fingerprinting, not cryptographic security
+				h := md5.Sum(data) // nox:ignore CRYPTO-001 -- MD5 provided for checksum/fingerprinting, not cryptographic security; #nosec G401 -- MD5 provided for checksum/fingerprinting, not cryptographic security
 				computed = hex.EncodeToString(h[:])
 			case "sha1":
-				h := sha1.Sum(data) // #nosec G401 -- SHA1 provided for checksum/fingerprinting, not cryptographic security
+				h := sha1.Sum(data) // nox:ignore CRYPTO-001 -- SHA1 provided for checksum/fingerprinting, not cryptographic security; #nosec G401 -- SHA1 provided for checksum/fingerprinting, not cryptographic security
 				computed = hex.EncodeToString(h[:])
 			case "sha256":
 				h := sha256.Sum256(data)

--- a/contrib/pack-string/string.go
+++ b/contrib/pack-string/string.go
@@ -578,11 +578,11 @@ func hashTool() tool.Tool {
 
 			switch strings.ToLower(algorithm) {
 			case "md5":
-				hash := md5.Sum(data) // #nosec G401 -- MD5 used for checksums/fingerprinting, not cryptographic security
+				hash := md5.Sum(data) // nox:ignore CRYPTO-001 -- MD5 used for checksums/fingerprinting, not cryptographic security; #nosec G401 -- MD5 used for checksums/fingerprinting, not cryptographic security
 				hashHex = hex.EncodeToString(hash[:])
 				algorithm = "md5"
 			case "sha1":
-				hash := sha1.Sum(data) // #nosec G401 -- SHA1 used for checksums/fingerprinting, not cryptographic security
+				hash := sha1.Sum(data) // nox:ignore CRYPTO-001 -- SHA1 used for checksums/fingerprinting, not cryptographic security; #nosec G401 -- SHA1 used for checksums/fingerprinting, not cryptographic security
 				hashHex = hex.EncodeToString(hash[:])
 				algorithm = "sha1"
 			default:

--- a/contrib/storage-gcs/gcs.go
+++ b/contrib/storage-gcs/gcs.go
@@ -101,7 +101,7 @@ func (s *ArtifactStore) Store(ctx context.Context, content io.Reader, opts artif
 	var hasher hash.Hash
 	reader := content
 	if opts.ComputeChecksum {
-		hasher = md5.New()
+		hasher = md5.New() // nox:ignore CRYPTO-001 -- MD5 is the integrity checksum the Cloud Storage API itself specifies for uploads; it guards against transmission corruption on a TLS-protected channel, not against an adversary
 		reader = io.TeeReader(content, hasher)
 	}
 


### PR DESCRIPTION
Closes #86. Unblocks CI now that the shared gate fails on `CRYPTO-*`/`HARDEN-*`/`PERM-*`/`MEMSAFE-*` at any severity (klarlabs-studio/.github#58) — agent-go is the only repo in the fleet with findings.

### Nothing changed in this repo

`CRYPTO-001` matched `md5.New()` but **not** `md5.Sum()` — the more idiomatic one-shot form — so these sites were invisible. nox fixed that and the count went **10 → 18**; every new one is a `Sum()` call that was always there.

### Triaged per site, not waived in bulk

| files | finding | why it is not a vulnerability |
|---|---|---|
| `pack-crypto`, `pack-hash`, `pack-string`, `pack-fileops` (17) | MD5/SHA-1 | **user-selectable algorithms** in a checksum/fingerprinting tool, sitting in the same `switch` as `sha256` and `sha512`. A library computing the digest its caller asked for is not a service silently hashing credentials. All 17 **already carried a `#nosec G401`** saying exactly this — triaged for gosec long ago. |
| `storage-gcs/gcs.go:104` (1) | MD5 | the integrity checksum **the Cloud Storage API itself specifies** for uploads. Guards against transmission corruption on a TLS-protected channel, not against an adversary. The only site with no prior annotation. |

I read every one rather than blanket-waiving; if any had been security-bearing it would have wanted a code change instead.

### Why `nox:ignore` over a baseline or VEX

The reason lives on the line it excuses, beside the `#nosec` that already explains it, and survives re-fingerprinting. A baseline entry records only that a finding existed, not why it is acceptable.

### One trap worth knowing

**The directive must come first in the comment.**

```go
// #nosec G401 -- reason; nox:ignore CRYPTO-001 -- reason   // NOT honoured
// nox:ignore CRYPTO-001 -- reason; #nosec G401 -- reason   // honoured
```

I verified this before editing, because the failure is silent — the finding simply stays unsuppressed and the build stays red with no indication why.

### Verified

18 findings → **18 suppressed, 0 unsuppressed**. The gate's own jq query returns 0. `gofmt`, build and tests clean.