### PR TITLE
feat: extend API seal and sandbox coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,11 @@ go build ./...
 go test -race -short ./...
 ```
 
+**Go version:** agent-go requires **Go 1.26.2+**. The floor is set by
+`go.klarlabs.de/axi` (governance). Other Klarlabs deps (`statekit`, `fortify`,
+`bolt`) allow 1.25+, but axi does not — do not lower the `go` directive in
+`go.mod` without an axi release that does.
+
 ## Project Structure
 
 - `domain/` — Core domain layer (no external dependencies)

--- a/contrib/pack-fileops/fileops.go
+++ b/contrib/pack-fileops/fileops.go
@@ -38,6 +38,7 @@ import (
 	"go.klarlabs.de/agent/domain/agent"
 	"go.klarlabs.de/agent/domain/pack"
 	"go.klarlabs.de/agent/domain/tool"
+	"go.klarlabs.de/agent/sandbox"
 )
 
 // Pack returns the file operations tools pack.
@@ -67,34 +68,8 @@ func Pack(baseDir string) *pack.Pack {
 
 // --- Path security ---
 
-// safePath resolves a user-provided path relative to baseDir and ensures
-// it does not escape the sandbox. Returns the absolute path or an error.
 func safePath(baseDir, userPath string) (string, error) {
-	fullPath := filepath.Join(baseDir, filepath.Clean(userPath))
-	if !isSubPath(baseDir, fullPath) {
-		return "", fmt.Errorf("path traversal attempt: %s", userPath)
-	}
-	return fullPath, nil
-}
-
-// isSubPath checks if the given path is under the base directory.
-func isSubPath(base, path string) bool {
-	absBase, err := filepath.Abs(base)
-	if err != nil {
-		return false
-	}
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return false
-	}
-	rel, err := filepath.Rel(absBase, absPath)
-	if err != nil {
-		return false
-	}
-	if rel == "." {
-		return true
-	}
-	return !filepath.IsAbs(rel) && !strings.HasPrefix(rel, "..")
+	return sandbox.SafePath(baseDir, userPath)
 }
 
 // --- Input/Output types ---
@@ -947,7 +922,7 @@ func extractZip(archivePath, outputDir, baseDir string) (int, error) {
 	for _, zf := range r.File {
 		// Validate extracted path stays within sandbox
 		destPath := filepath.Join(outputDir, filepath.Clean(zf.Name))
-		if !isSubPath(baseDir, destPath) {
+		if !sandbox.IsUnderBase(baseDir, destPath) {
 			return count, fmt.Errorf("zip contains path traversal entry: %s", zf.Name)
 		}
 
@@ -1015,7 +990,7 @@ func extractTar(archivePath, outputDir, baseDir string, compressed bool) (int, e
 		}
 
 		destPath := filepath.Join(outputDir, filepath.Clean(header.Name))
-		if !isSubPath(baseDir, destPath) {
+		if !sandbox.IsUnderBase(baseDir, destPath) {
 			return count, fmt.Errorf("tar contains path traversal entry: %s", header.Name)
 		}
 

--- a/contrib/pack-fileops/go.mod
+++ b/contrib/pack-fileops/go.mod
@@ -2,6 +2,4 @@ module go.klarlabs.de/agent/contrib/pack-fileops
 
 go 1.26.2
 
-require go.klarlabs.de/agent v0.15.0
-
-replace go.klarlabs.de/agent => ../..
+require go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf

--- a/contrib/pack-fileops/go.mod
+++ b/contrib/pack-fileops/go.mod
@@ -3,3 +3,5 @@ module go.klarlabs.de/agent/contrib/pack-fileops
 go 1.26.2
 
 require go.klarlabs.de/agent v0.15.0
+
+replace go.klarlabs.de/agent => ../..

--- a/contrib/pack-fileops/go.sum
+++ b/contrib/pack-fileops/go.sum
@@ -1,2 +1,0 @@
-go.klarlabs.de/agent v0.15.0 h1:2g7AwPkQuUoLmli/0JlmDGR/mhtPGCsqt8bSpxFp98A=
-go.klarlabs.de/agent v0.15.0/go.mod h1:bv1jLH8B+vHpGLq0HH66L1evUGHpvWMy2wYgmBJn0Lk=

--- a/contrib/pack-fileops/go.sum
+++ b/contrib/pack-fileops/go.sum
@@ -1,0 +1,2 @@
+go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf h1:6ZYc+9rBfQFtFHihlKAmF9Rc7pmGW92pcqvf+iz5TP0=
+go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf/go.mod h1:XuUs7LzbDNJjGEu+kHBB6Rx0jBJk6P9aBr9j9z/E6EI=

--- a/contrib/pack-fileops/pack_test.go
+++ b/contrib/pack-fileops/pack_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"go.klarlabs.de/agent/domain/tool"
+	"go.klarlabs.de/agent/sandbox"
 )
 
 func TestPack_RegistersTools(t *testing.T) {
@@ -462,8 +463,8 @@ func TestIsSubPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isSubPath(tc.base, tc.path); got != tc.expected {
-				t.Errorf("isSubPath(%q, %q) = %v, want %v", tc.base, tc.path, got, tc.expected)
+			if got := sandbox.IsUnderBase(tc.base, tc.path); got != tc.expected {
+				t.Errorf("sandbox.IsUnderBase(%q, %q) = %v, want %v", tc.base, tc.path, got, tc.expected)
 			}
 		})
 	}

--- a/contrib/pack-filesystem/go.mod
+++ b/contrib/pack-filesystem/go.mod
@@ -2,6 +2,4 @@ module go.klarlabs.de/agent/contrib/pack-filesystem
 
 go 1.26.2
 
-require go.klarlabs.de/agent v0.15.0
-
-replace go.klarlabs.de/agent => ../..
+require go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf

--- a/contrib/pack-filesystem/go.sum
+++ b/contrib/pack-filesystem/go.sum
@@ -1,0 +1,2 @@
+go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf h1:6ZYc+9rBfQFtFHihlKAmF9Rc7pmGW92pcqvf+iz5TP0=
+go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf/go.mod h1:XuUs7LzbDNJjGEu+kHBB6Rx0jBJk6P9aBr9j9z/E6EI=

--- a/contrib/pack-image/go.mod
+++ b/contrib/pack-image/go.mod
@@ -2,6 +2,4 @@ module go.klarlabs.de/agent/contrib/pack-image
 
 go 1.26.2
 
-require go.klarlabs.de/agent v0.15.0
-
-replace go.klarlabs.de/agent => ../..
+require go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf

--- a/contrib/pack-image/go.sum
+++ b/contrib/pack-image/go.sum
@@ -1,0 +1,2 @@
+go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf h1:6ZYc+9rBfQFtFHihlKAmF9Rc7pmGW92pcqvf+iz5TP0=
+go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf/go.mod h1:XuUs7LzbDNJjGEu+kHBB6Rx0jBJk6P9aBr9j9z/E6EI=

--- a/contrib/pack-monitoring/go.mod
+++ b/contrib/pack-monitoring/go.mod
@@ -2,6 +2,4 @@ module go.klarlabs.de/agent/contrib/pack-monitoring
 
 go 1.26.2
 
-require go.klarlabs.de/agent v0.15.0
-
-replace go.klarlabs.de/agent => ../..
+require go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf

--- a/contrib/pack-monitoring/go.sum
+++ b/contrib/pack-monitoring/go.sum
@@ -1,0 +1,2 @@
+go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf h1:6ZYc+9rBfQFtFHihlKAmF9Rc7pmGW92pcqvf+iz5TP0=
+go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf/go.mod h1:XuUs7LzbDNJjGEu+kHBB6Rx0jBJk6P9aBr9j9z/E6EI=

--- a/contrib/pack-pdf/go.mod
+++ b/contrib/pack-pdf/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/pdfcpu/pdfcpu v0.11.1
 	github.com/phpdave11/gofpdf v1.4.2
-	go.klarlabs.de/agent v0.15.0
+	go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf
 )
 
 require (
@@ -22,5 +22,3 @@ require (
 	golang.org/x/text v0.40.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace go.klarlabs.de/agent => ../..

--- a/contrib/pack-pdf/go.sum
+++ b/contrib/pack-pdf/go.sum
@@ -31,6 +31,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf h1:6ZYc+9rBfQFtFHihlKAmF9Rc7pmGW92pcqvf+iz5TP0=
+go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf/go.mod h1:XuUs7LzbDNJjGEu+kHBB6Rx0jBJk6P9aBr9j9z/E6EI=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/contrib/pack-shell/go.mod
+++ b/contrib/pack-shell/go.mod
@@ -2,6 +2,4 @@ module go.klarlabs.de/agent/contrib/pack-shell
 
 go 1.26.2
 
-require go.klarlabs.de/agent v0.15.0
-
-replace go.klarlabs.de/agent => ../..
+require go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf

--- a/contrib/pack-shell/go.sum
+++ b/contrib/pack-shell/go.sum
@@ -1,0 +1,2 @@
+go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf h1:6ZYc+9rBfQFtFHihlKAmF9Rc7pmGW92pcqvf+iz5TP0=
+go.klarlabs.de/agent v0.15.1-0.20260815153923-14af654b79bf/go.mod h1:XuUs7LzbDNJjGEu+kHBB6Rx0jBJk6P9aBr9j9z/E6EI=

--- a/interfaces/api/agent.go
+++ b/interfaces/api/agent.go
@@ -800,7 +800,6 @@ var NewPassthroughFactory = governance.NewPassthroughFactory
 // approval to axi while keeping run-level budget in agent-go (the default).
 var NewAxiFactory = governance.NewAxiFactory
 
-
 // Clock abstracts the source of wall-clock time for the runtime.
 type Clock = clock.Clock
 

--- a/interfaces/api/agent.go
+++ b/interfaces/api/agent.go
@@ -490,7 +490,7 @@ func WithPlanner(p domainplanner.Planner) Option {
 }
 
 // WithExecutor sets the resilient executor.
-func WithExecutor(e *resilience.Executor) Option {
+func WithExecutor(e *Executor) Option {
 	return func(c *engineConfig) {
 		c.executor = e
 	}
@@ -545,11 +545,11 @@ func WithBudgets(budgets map[string]int) Option {
 // the destructive-tool approval gate to an axi.Kernel (AxiFactory) while the
 // run-level budget stays in agent-go.
 //
-// Use governance.NewKernelFactory(approver) for full delegation — each run
+// Use api.NewKernelFactory(approver) for full delegation — each run
 // executes as one axi session so budget, approval, and evidence are all
-// axi-native. Use governance.NewPassthroughFactory(approver) to keep budget
+// axi-native. Use api.NewPassthroughFactory(approver) to keep budget
 // and approval fully in-process (approval via the engine middleware).
-func WithGovernance(f governance.Factory) Option {
+func WithGovernance(f GovernanceFactory) Option {
 	return func(c *engineConfig) {
 		c.governance = f
 	}
@@ -769,11 +769,37 @@ type LoggerConfig = logging.Config
 //
 //	logger := api.NewLoggerFromConfig(api.LoggerConfig{Level: "info", Format: "json"})
 //	engine, _ := api.New(api.WithPlanner(p), api.WithLogger(logger))
-func WithLogger(l *logging.Logger) Option {
+func WithLogger(l *Logger) Option {
 	return func(c *engineConfig) {
 		c.logger = l
 	}
 }
+
+// Executor is the resilient tool executor. Prefer api.NewDefaultExecutor
+// over importing infrastructure/resilience.
+type Executor = resilience.Executor
+
+// NewDefaultExecutor returns a resilient executor with default settings.
+func NewDefaultExecutor() *Executor {
+	return resilience.NewDefaultExecutor()
+}
+
+// GovernanceFactory constructs per-run governors. Prefer the api constructors
+// below over importing infrastructure/governance.
+type GovernanceFactory = governance.Factory
+
+// NewKernelFactory returns a factory that fully delegates budget, approval,
+// and evidence to one axi session per run.
+var NewKernelFactory = governance.NewKernelFactory
+
+// NewPassthroughFactory returns a factory that keeps budget and approval
+// in-process (approval via engine middleware).
+var NewPassthroughFactory = governance.NewPassthroughFactory
+
+// NewAxiFactory returns a factory that delegates only destructive-tool
+// approval to axi while keeping run-level budget in agent-go (the default).
+var NewAxiFactory = governance.NewAxiFactory
+
 
 // Clock abstracts the source of wall-clock time for the runtime.
 type Clock = clock.Clock

--- a/interfaces/api/agent_test.go
+++ b/interfaces/api/agent_test.go
@@ -8,7 +8,6 @@ import (
 
 	"go.klarlabs.de/agent/domain/tool"
 	"go.klarlabs.de/agent/infrastructure/planner"
-	"go.klarlabs.de/agent/infrastructure/resilience"
 	"go.klarlabs.de/agent/infrastructure/storage/filesystem"
 	api "go.klarlabs.de/agent/interfaces/api"
 )
@@ -253,7 +252,7 @@ func TestNew_WithExecutor(t *testing.T) {
 	t.Run("creates engine with custom executor", func(t *testing.T) {
 		t.Parallel()
 
-		executor := resilience.NewDefaultExecutor()
+		executor := api.NewDefaultExecutor()
 
 		mockPlanner := api.NewMockPlanner(
 			api.NewFinishDecision("done", nil),

--- a/sandbox/contract_test.go
+++ b/sandbox/contract_test.go
@@ -1,0 +1,63 @@
+package sandbox_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"go.klarlabs.de/agent/sandbox"
+)
+
+// Pack contract: every BaseDir-jailed pack must reject these inputs via SafePath.
+func TestContract_PathJail(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+
+	rejects := []string{
+		"",
+		"/etc/passwd",
+		"../escape",
+		filepath.Join("..", "..", "etc", "passwd"),
+		filepath.Join("ok", "..", "..", "etc"),
+	}
+	for _, p := range rejects {
+		if _, err := sandbox.SafePath(base, p); err == nil {
+			t.Errorf("SafePath(%q) should reject", p)
+		}
+	}
+
+	ok, err := sandbox.SafePath(base, filepath.Join("a", "b.txt"))
+	if err != nil {
+		t.Fatalf("SafePath allowed path: %v", err)
+	}
+	if !sandbox.IsUnderBase(base, ok) {
+		t.Fatalf("resolved path %q not under base", ok)
+	}
+}
+
+// Pack contract: host allowlists deny-all when empty.
+func TestContract_HostAllowlist(t *testing.T) {
+	t.Parallel()
+	if sandbox.HostAllowed("example.com", nil) {
+		t.Fatal("empty allowlist must deny")
+	}
+	if sandbox.HostAllowed("example.com", []string{}) {
+		t.Fatal("empty allowlist must deny")
+	}
+	if !sandbox.HostAllowed("metrics.prod.example.com", []string{"*.example.com"}) {
+		t.Fatal("wildcard should allow")
+	}
+}
+
+// Pack contract: command allowlists deny-all when empty; argv-only model.
+func TestContract_CommandAllowlist(t *testing.T) {
+	t.Parallel()
+	if sandbox.CommandAllowed("echo", nil) {
+		t.Fatal("empty allowlist must deny")
+	}
+	if sandbox.CommandAllowed("rm", []string{"echo"}) {
+		t.Fatal("unlisted command must deny")
+	}
+	if !sandbox.CommandAllowed("echo", []string{"echo"}) {
+		t.Fatal("listed basename must allow")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up trust hardening after #94:

- **pack-fileops** uses shared `sandbox.SafePath`
- **API seal**: `Executor` / `GovernanceFactory` + constructors on `interfaces/api`
- **Pack contract tests** for path/host/command allowlists
- **Drop local `replace`**: sandbox-using packs pin `go.klarlabs.de/agent` to the post-#94 pseudo-version so Quality `GOWORK=off` tidy/build works without replace
- **Go floor**: documented that **1.26.2 is required by `axi`** — cannot lower until axi ships a lower floor (`statekit`/`fortify`/`bolt` already allow 1.25+)

## Test plan
- [x] `GOWORK=off go mod tidy/build/test` for sandbox-using packs
- [x] sandbox + api tests
- [ ] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a004c3-0d63-7667-8815-db3304a4e158?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a004c3-0d63-7667-8815-db3304a4e158&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

