### PR TITLE
fix: make first-agent onboarding path actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 **Build trustworthy AI agents in Go.** A state-driven runtime where intelligence is constrained by design, not hope. Works great for a **single agent** — scales to **multi-agent systems** when you're ready.
 
 ```go
+import agent "go.klarlabs.de/agent/interfaces/api"
+
 engine, _ := agent.New(
-    agent.WithTools(readFile, writeFile),
+    agent.WithTool(readFile),
     agent.WithPlanner(llmPlanner),
     agent.WithBudget("tool_calls", 50),
 )
@@ -77,7 +79,7 @@ interfaces/api/     → Public API (5 lines to get started)
 application/        → Engine (Run, Stream, Replay, Fork)
 domain/             → Pure types (State, Decision, Tool, Policy, Protocol)
 infrastructure/     → Implementations (statekit, fortify, storage, planner)
-contrib/            → 134 optional modules (storage, tools, enhancements)
+contrib/            → 141 optional modules (storage, tools, enhancements)
 ```
 
 ---
@@ -86,8 +88,12 @@ contrib/            → 134 optional modules (storage, tools, enhancements)
 
 ### Installation
 
+Requires **Go 1.26.2+** (module floor; see `CONTRIBUTING.md`).
+
 ```bash
-go get go.klarlabs.de/agent
+mkdir my-first-agent && cd my-first-agent
+go mod init my-first-agent
+go get go.klarlabs.de/agent/interfaces/api@latest
 ```
 
 ### Your First Agent (5 minutes)
@@ -120,7 +126,8 @@ func main() {
         }).
         MustBuild()
 
-    // 2. Create a scripted planner (for testing - swap with LLM in production)
+    // 2. Create a scripted planner (for testing — swap with an LLM planner in production)
+    // Canonical flow: intake → explore → decide → done (Finish is only valid from decide/validate).
     planner := agent.NewScriptedPlanner(
         agent.ScriptStep{
             ExpectState: agent.StateIntake,
@@ -132,11 +139,17 @@ func main() {
         },
         agent.ScriptStep{
             ExpectState: agent.StateExplore,
+            Decision:    agent.NewTransitionDecision(agent.StateDecide, "ready to finish"),
+        },
+        agent.ScriptStep{
+            ExpectState: agent.StateDecide,
             Decision:    agent.NewFinishDecision("completed", json.RawMessage(`{"status":"done"}`)),
         },
     )
 
     // 3. Build and run the engine
+    // Default tool eligibility allows registered tools in explore/decide/act/validate.
+    // For production, prefer an explicit allow-list via WithToolEligibility.
     engine, err := agent.New(
         agent.WithTool(greetTool),
         agent.WithPlanner(planner),
@@ -158,11 +171,13 @@ func main() {
 
 Run it:
 ```bash
-go run main.go
+go run .
 # Output:
-# Status: done
+# Status: completed
 # Result: {"status":"done"}
 ```
+
+Or try the in-repo minimal example: `go run ./example/01-minimal`
 
 ---
 

--- a/application/engine.go
+++ b/application/engine.go
@@ -161,7 +161,12 @@ func NewEngine(config EngineConfig) (*Engine, error) {
 		e.executor = resilience.NewExecutorWithOptions(resilience.WithClock(e.clock))
 	}
 	if e.eligibility == nil {
-		e.eligibility = policy.NewToolEligibility()
+		// Sensible onboarding default: allow all registered tools in
+		// explore/decide/act/validate (wildcard "*"). Intake and terminal
+		// states still deny tools. Callers who want deny-by-default should
+		// pass policy.NewToolEligibility() (empty) or an explicit allow-list
+		// via WithToolEligibility / WithEligibility.
+		e.eligibility = policy.NewDefaultToolEligibility()
 	}
 	if e.transitions == nil {
 		e.transitions = policy.DefaultTransitions()

--- a/application/engine_test.go
+++ b/application/engine_test.go
@@ -101,6 +101,13 @@ func TestNewEngine_SetsDefaults(t *testing.T) {
 	if engine.eligibility == nil {
 		t.Error("expected default eligibility to be set")
 	}
+	// Onboarding default: wildcard allow in explore (and decide/act/validate).
+	if !engine.eligibility.IsAllowed(agent.StateExplore, "any_tool") {
+		t.Error("expected default eligibility to allow tools in explore via wildcard")
+	}
+	if engine.eligibility.IsAllowed(agent.StateIntake, "any_tool") {
+		t.Error("expected default eligibility to deny tools in intake")
+	}
 	if engine.transitions == nil {
 		t.Error("expected default transitions to be set")
 	}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ Get your first agent running in 5 minutes.
 
 ## Prerequisites
 
-- Go 1.21 or later
+- **Go 1.26.2 or later** (module floor; see `CONTRIBUTING.md`)
 - A code editor
 
 ## Step 1: Create a New Project
@@ -13,7 +13,7 @@ Get your first agent running in 5 minutes.
 mkdir my-first-agent
 cd my-first-agent
 go mod init my-first-agent
-go get go.klarlabs.de/agent
+go get go.klarlabs.de/agent/interfaces/api@latest
 ```
 
 ## Step 2: Create Your Agent
@@ -56,7 +56,8 @@ func main() {
         }).
         MustBuild()
 
-    // Create a scripted planner that defines the agent's behavior
+    // Create a scripted planner that defines the agent's behavior.
+    // Finish is only allowed from decide (or validate) under DefaultTransitions.
     planner := agent.NewScriptedPlanner(
         // Step 1: Move from intake to explore
         agent.ScriptStep{
@@ -68,14 +69,21 @@ func main() {
             ExpectState: agent.StateExplore,
             Decision:    agent.NewCallToolDecision("add", json.RawMessage(`{"a": 5, "b": 3}`), "adding numbers"),
         },
-        // Step 3: Finish with the result
+        // Step 3: Move to decide
         agent.ScriptStep{
             ExpectState: agent.StateExplore,
+            Decision:    agent.NewTransitionDecision(agent.StateDecide, "ready to finish"),
+        },
+        // Step 4: Finish with the result
+        agent.ScriptStep{
+            ExpectState: agent.StateDecide,
             Decision:    agent.NewFinishDecision("calculation complete", json.RawMessage(`{"answer": 8}`)),
         },
     )
 
-    // Build the engine
+    // Build the engine.
+    // Default eligibility allows registered tools in explore/decide/act/validate.
+    // For production, prefer an explicit allow-list via WithToolEligibility.
     engine, err := agent.New(
         agent.WithTool(addTool),
         agent.WithPlanner(planner),
@@ -94,30 +102,30 @@ func main() {
     fmt.Println("=== Agent Run Complete ===")
     fmt.Printf("Status: %s\n", run.Status)
     fmt.Printf("Result: %s\n", run.Result)
-    fmt.Printf("Steps taken: %d\n", run.StepCount)
+    fmt.Printf("Final state: %s\n", run.CurrentState)
 }
 ```
 
 ## Step 3: Run Your Agent
 
 ```bash
-go run main.go
+go run .
 ```
 
 Expected output:
 ```
 === Agent Run Complete ===
-Status: done
+Status: completed
 Result: {"answer": 8}
-Steps taken: 3
+Final state: done
 ```
 
 ## What Just Happened?
 
 1. **Tool Creation**: We created an `add` tool with annotations indicating it's read-only and idempotent
 2. **Planner Setup**: We used a `ScriptedPlanner` which follows a predetermined script (perfect for testing)
-3. **Engine Configuration**: We built the engine with our tool and planner
-4. **Execution**: The engine ran through the scripted steps: intake → explore → done
+3. **Engine Configuration**: We built the engine with our tool and planner (default eligibility is enough to start)
+4. **Execution**: The engine ran through the scripted steps: intake → explore → decide → done
 
 ## Understanding the State Machine
 
@@ -131,12 +139,28 @@ intake (start)
 explore (gathering info)
    ↓
    └─→ called "add" tool with {a: 5, b: 3}
-   └─→ "calculation complete"
+   └─→ "ready to finish"
 
-done (terminal)
+decide
+   ↓
+   └─→ Finish → done (terminal)
 ```
 
 ## Next Steps
+
+### Tighten Tool Eligibility (recommended for production)
+
+```go
+eligibility := agent.NewToolEligibilityWith(agent.EligibilityRules{
+    agent.StateExplore: {"add"},
+})
+
+engine, _ := agent.New(
+    agent.WithTool(addTool),
+    agent.WithPlanner(planner),
+    agent.WithToolEligibility(eligibility),
+)
+```
 
 ### Add More Tools
 
@@ -167,36 +191,14 @@ engine, _ := agent.New(
 
 ### Use a Real LLM Planner
 
-```go
-import "go.klarlabs.de/agent/infrastructure/planner/provider/anthropic"
+See [`example/04-llm-planner`](../example/04-llm-planner/) and the
+[`contrib/planner-llm`](../contrib/planner-llm/) module for provider wiring.
 
-provider, _ := anthropic.New(
-    anthropic.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY")),
-    anthropic.WithModel("claude-sonnet-4-20250514"),
-)
+### Explore Examples
 
-llmPlanner := planner.NewLLMPlanner(planner.LLMPlannerConfig{
-    Provider: provider,
-})
-
-engine, _ := agent.New(
-    agent.WithTool(addTool),
-    agent.WithPlanner(llmPlanner),
-)
-```
-
-### Add Observability
-
-```go
-import "go.klarlabs.de/agent/infrastructure/observability"
-
-tracer, _ := observability.NewTracer("calculator-agent")
-
-engine, _ := agent.New(
-    agent.WithTool(addTool),
-    agent.WithPlanner(planner),
-    agent.WithMiddleware(observability.TracingMiddleware(tracer)),
-)
+```bash
+go run ./example/01-minimal
+go run ./example/flagship
 ```
 
 ## Learn More

--- a/example/01-minimal/README.md
+++ b/example/01-minimal/README.md
@@ -19,7 +19,7 @@ go run main.go
 
 ```
 === Minimal Agent Example ===
-Status: done
+Status: completed
 Result: {"status":"complete"}
 ```
 
@@ -47,16 +47,28 @@ planner := agent.NewScriptedPlanner(
 )
 ```
 
-### 3. Build Engine
+### 3. Allow the tool in explore (explicit allow-list)
+
+```go
+eligibility := agent.NewToolEligibility()
+eligibility.Allow(agent.StateExplore, "echo")
+```
+
+Omitting eligibility also works: the engine defaults to
+`NewDefaultToolEligibility()` (wildcard allow in explore/decide/act/validate).
+This example uses an explicit allow-list to show the production pattern.
+
+### 4. Build Engine
 
 ```go
 engine, err := agent.New(
     agent.WithTool(echoTool),
     agent.WithPlanner(planner),
+    agent.WithToolEligibility(eligibility),
 )
 ```
 
-### 4. Run
+### 5. Run
 
 ```go
 run, err := engine.Run(context.Background(), "Echo a message")

--- a/example/02-tools/README.md
+++ b/example/02-tools/README.md
@@ -20,7 +20,7 @@ go run main.go
 
 ```
 === Tools Example ===
-Status: done
+Status: completed
 Steps: 5
 
 Output file contents: Processed output!

--- a/example/04-llm-planner/README.md
+++ b/example/04-llm-planner/README.md
@@ -45,7 +45,7 @@ Goal: What is 15 multiplied by 7?
   [calculate] multiply(15, 7) = 105
 
 === Result ===
-Status: done
+Status: completed
 Steps: 3
 Result: {"answer": 105, "explanation": "15 × 7 = 105"}
 ```

--- a/interfaces/api/agent.go
+++ b/interfaces/api/agent.go
@@ -25,18 +25,13 @@
 //	    api.ScriptStep{ExpectState: api.StateDecide, Decision: api.NewFinishDecision("completed", result)},
 //	)
 //
-//	// 3. Configure tool eligibility
-//	// Option A: Declarative style (recommended for static configuration)
+//	// 3. Configure tool eligibility (optional)
+//	// When omitted, the engine uses NewDefaultToolEligibility(): wildcard allow
+//	// in explore/decide/act/validate. Prefer an explicit allow-list in production.
 //	eligibility := api.NewToolEligibilityWith(api.EligibilityRules{
 //	    api.StateExplore: {"echo", "read_file"},
 //	    api.StateAct:     {"write_file"},
 //	})
-//
-//	// Option B: Imperative style (useful for dynamic configuration)
-//	eligibility := api.NewToolEligibility()
-//	eligibility.Allow(api.StateExplore, "echo")
-//	eligibility.Allow(api.StateExplore, "read_file")
-//	eligibility.Allow(api.StateAct, "write_file")
 //
 //	// 4. Create and run the engine
 //	engine, _ := api.New(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Simulated a fresh user following the README “5 minute” path. It was **not** easy — the advertised quick start failed for multiple independent reasons. This PR fixes the path end-to-end.

## What was broken

1. **Hero snippet** used non-existent APIs (`agent.WithTools`, root `go.klarlabs.de/agent` as if it were the engine package).
2. **Install** via `go get go.klarlabs.de/agent` left incomplete `go.sum` for transitive deps; `go get …/interfaces/api` is the reliable entry.
3. **Missing eligibility**: engine defaulted to empty deny-all, so the README sample died with `tool not allowed in current state: greet in state explore`.
4. **Invalid Finish state**: samples finished from `explore`, but `DefaultTransitions` only allow `decide`/`validate` → `done`.
5. **Doc drift**: Go 1.21 vs 1.26.2, `Status: done` vs `completed`, `run.StepCount` (doesn’t exist), contrib count 134 vs 141.

## Fixes

- Default unset eligibility to `NewDefaultToolEligibility()` (wildcard in explore/decide/act/validate; intake/terminal still deny). Explicit empty allow-lists still work via `NewToolEligibility()`.
- Align README hero, Quick Start, and `docs/quickstart.md` with the real API, install command, canonical state flow, and expected output.
- Correct example README expected statuses and teach explicit eligibility in `01-minimal`.

## Verification

- Local replace of the module + README sample → `Status: completed`.
- `go test -race ./application/ ./interfaces/api/ ./domain/policy/ ./test/` green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a004c3-0d63-7667-8815-db3304a4e158?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a004c3-0d63-7667-8815-db3304a4e158&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

