### PR TITLE
docs+release: concept API polish and prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-15
+
+### Added
+- Implemented previously stubbed contrib packs (filesystem, image, pdf, vectordb,
+  llm, secrets, messaging, monitoring, shell, search, and related packs).
+- `sandbox` package (`SafePath`, host/command allow-lists) wired into filesystem,
+  image, pdf, shell, monitoring, and fileops packs.
+- Public API re-exports for `Executor`, `GovernanceFactory`, and
+  `NewAskHumanDecision`.
+- Planner contract sealed in `domain/planner` (re-exported via `interfaces/api`).
+
 ### Fixed
+- First-agent onboarding path: default tool eligibility is
+  `NewDefaultToolEligibility` when unset; README/quickstart match the real API
+  and canonical Finish-from-decide flow.
+- Concept docs aligned with the public API (removed aspirational symbols such as
+  `WithTools`, `StepCount`, `FailureReason`, `NewDynamicEligibility`).
 - Middleware options (`WithRateLimit`, `WithMiddleware`, etc.) append to the
   default policy chain instead of replacing eligibility/approval/validation.
 - `ContinueRun` and `ResumeWithInput` share `driveLoop` with loop detection
@@ -17,14 +33,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - EventStore/RunStore persistence failures fail the run when strict audit is
   enabled (default whenever an EventStore is configured); override with
   `WithStrictAudit`.
+- Custom states cannot enable side effects (`AllowsSideEffects` rejected at
+  register time).
 - Stub contrib packs are labeled `[STUB]` with `metadata.status=stub`.
 - `scripts/new-contrib.sh` no longer emits a local `replace` directive.
-- Docs/version alignment: `version.go` → 0.15.0; event/module counts; coverage
-  thresholds documented via `.coverctl.yaml`; CI reusable workflows pinned.
+- Contrib modules no longer ship local `replace` directives for the root module.
 
 ### Changed
+- Go module floor documented as **1.26.2+** (required by `go.klarlabs.de/axi`).
 - Evidence / AskHuman / Complete / TransitionTo gain `*At` clock-injected
   variants used by the engine for deterministic timestamps.
+- `version.go` → `0.16.0`.
 
 ## [0.15.0] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,7 +238,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - go.opentelemetry.io/otel v1.39.0
 - And various cloud SDKs (AWS, GCP, Azure)
 
-[unreleased]: https://github.com/klarlabs-studio/agent-go/compare/v0.7.0...HEAD
+[unreleased]: https://github.com/klarlabs-studio/agent-go/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/klarlabs-studio/agent-go/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/klarlabs-studio/agent-go/releases/tag/v0.15.0
 [0.7.0]: https://github.com/klarlabs-studio/agent-go/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/klarlabs-studio/agent-go/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/klarlabs-studio/agent-go/compare/v0.1.0...v0.5.0

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -73,8 +73,8 @@ Real LLMs are unpredictable. agent-go separates the intelligence layer (Planner)
 // Testing: Use ScriptedPlanner for deterministic behavior
 testPlanner := agent.NewScriptedPlanner(steps...)
 
-// Production: Use LLM planner for real intelligence
-prodPlanner := planner.NewLLMPlanner(config)
+// Production: Use an LLM planner (see contrib/planner-llm)
+prodPlanner := plannerllm.NewPlanner(config)
 
 // Same engine, same behavior guarantees
 engine, _ := agent.New(

--- a/docs/concepts/planners.md
+++ b/docs/concepts/planners.md
@@ -12,14 +12,16 @@ type Planner interface {
 }
 
 type PlanRequest struct {
-    RunID        string              // Current run identifier
-    CurrentState State               // Where the agent is
-    Evidence     []Evidence          // What the agent has learned
-    AllowedTools []string            // Tools available in current state
-    Budgets      BudgetSnapshot      // Remaining budget limits
-    Vars         map[string]any      // User-defined variables
+    RunID        string
+    CurrentState State
+    Evidence     []Evidence
+    AllowedTools []string
+    Budgets      BudgetSnapshot
+    Vars         map[string]any
 }
 ```
+
+Import via `agent "go.klarlabs.de/agent/interfaces/api"` — `Planner` and `PlanRequest` are re-exported there.
 
 ## Decision Types
 
@@ -27,56 +29,51 @@ Planners return one of five decision types:
 
 ### CallTool
 
-Execute a tool with given input:
-
 ```go
 decision := agent.NewCallToolDecision(
-    "read_file",                              // Tool name
-    json.RawMessage(`{"path": "/tmp/x"}`),    // Input
-    "gathering information",                  // Reason
+    "read_file",
+    json.RawMessage(`{"path": "/tmp/x"}`),
+    "gathering information",
 )
 ```
 
 ### Transition
 
-Move to a different state:
-
 ```go
 decision := agent.NewTransitionDecision(
-    agent.StateAct,          // Target state
-    "ready to make changes", // Reason
+    agent.StateAct,
+    "ready to make changes",
 )
 ```
 
 ### Finish
 
-Complete successfully:
+Complete successfully. Under `DefaultTransitions`, **Finish is only valid from `decide` or `validate`** (those states may transition to `done`).
 
 ```go
 decision := agent.NewFinishDecision(
-    "task completed",                        // Reason
-    json.RawMessage(`{"result": "success"}`), // Result
+    "task completed",
+    json.RawMessage(`{"result": "success"}`),
 )
 ```
 
 ### Fail
 
-Terminate with failure:
-
 ```go
 decision := agent.NewFailDecision(
-    "cannot proceed without API key", // Reason
+    "cannot proceed without API key",
+    nil, // optional underlying error
 )
 ```
 
-### AskHuman (future)
+### AskHuman
 
-Request human input:
+Pause for human input, then resume with `engine.ResumeWithInput`:
 
 ```go
 decision := agent.NewAskHumanDecision(
-    "Should I delete these 100 files?",  // Question
-    []string{"yes", "no", "review"},     // Options
+    "Should I delete these 100 files?",
+    "yes", "no", "review",
 )
 ```
 
@@ -98,6 +95,10 @@ planner := agent.NewScriptedPlanner(
     },
     agent.ScriptStep{
         ExpectState: agent.StateExplore,
+        Decision:    agent.NewTransitionDecision(agent.StateDecide, "ready"),
+    },
+    agent.ScriptStep{
+        ExpectState: agent.StateDecide,
         Decision:    agent.NewFinishDecision("done", result),
     },
 )
@@ -107,156 +108,100 @@ planner := agent.NewScriptedPlanner(
 
 ### MockPlanner
 
-Returns a single fixed decision:
+Returns decisions in order (or a single fixed decision):
 
 ```go
 planner := agent.NewMockPlanner(
+    agent.NewTransitionDecision(agent.StateExplore, "start"),
+    agent.NewTransitionDecision(agent.StateDecide, "decide"),
     agent.NewFinishDecision("immediate finish", nil),
 )
 ```
 
 **Use for**: Simple tests, edge case testing
 
-### FunctionPlanner
+### RuleBasedPlanner / HybridPlanner
 
-Uses a custom function:
+Go-native rules evaluated in priority order; hybrid adds any fallback planner (for example an LLM):
 
 ```go
-planner := agent.NewFunctionPlanner(func(ctx context.Context, req agent.PlanRequest) (agent.Decision, error) {
-    // Custom logic
-    if req.CurrentState == agent.StateIntake {
-        return agent.NewTransitionDecision(agent.StateExplore, "starting"), nil
-    }
+rules := agent.NewRuleBasedPlanner(
+    agent.NewFailDecision("no rule matched", nil),
+    // rules built with agent.NewRule(...)
+)
 
-    if len(req.Evidence) > 5 {
-        return agent.NewFinishDecision("enough info", nil), nil
-    }
-
-    return agent.NewCallToolDecision("gather_more", nil, "need more"), nil
-})
+hybrid := agent.NewHybridPlanner(rules, llmFallback)
 ```
 
-**Use for**: Testing specific behaviors, simple heuristics
+**Use for**: Deterministic business rules, with optional LLM fallback
 
 ## LLM Planners
 
-For production agents, use LLM-powered planners:
-
-### Anthropic (Claude)
+For production agents, use the contrib LLM planner module:
 
 ```go
-import "go.klarlabs.de/agent/infrastructure/planner/provider/anthropic"
-
-provider, _ := anthropic.New(
-    anthropic.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY")),
-    anthropic.WithModel("claude-sonnet-4-20250514"),
+import (
+    plannerllm "go.klarlabs.de/agent/contrib/planner-llm"
+    "go.klarlabs.de/agent/contrib/planner-llm/providers"
 )
 
-llmPlanner := planner.NewLLMPlanner(planner.LLMPlannerConfig{
-    Provider:     provider,
-    SystemPrompt: "You are a helpful file management agent...",
-    Temperature:  0.7,
+provider := providers.NewAnthropicProvider(providers.AnthropicConfig{
+    APIKey: os.Getenv("ANTHROPIC_API_KEY"),
+    Model:  "claude-sonnet-4-20250514",
 })
+
+llmPlanner := plannerllm.NewPlanner(plannerllm.Config{
+    Provider:    provider,
+    Temperature: 0.7,
+    MaxTokens:   4096,
+})
+
+engine, _ := agent.New(agent.WithPlanner(llmPlanner), /* tools... */)
 ```
 
-### OpenAI (GPT-4)
-
-```go
-import "go.klarlabs.de/agent/infrastructure/planner/provider/openai"
-
-provider, _ := openai.New(
-    openai.WithAPIKey(os.Getenv("OPENAI_API_KEY")),
-    openai.WithModel("gpt-4-turbo"),
-)
-```
-
-### Google (Gemini)
-
-```go
-import "go.klarlabs.de/agent/infrastructure/planner/provider/gemini"
-
-provider, _ := gemini.New(
-    gemini.WithAPIKey(os.Getenv("GEMINI_API_KEY")),
-    gemini.WithModel("gemini-pro"),
-)
-```
-
-### Ollama (Local)
-
-```go
-import "go.klarlabs.de/agent/infrastructure/planner/provider/ollama"
-
-provider, _ := ollama.New(
-    ollama.WithBaseURL("http://localhost:11434"),
-    ollama.WithModel("llama3"),
-)
-```
+Other providers live under `contrib/planner-llm/providers` (OpenAI, Gemini, Ollama, Bedrock, Cohere, Copilot). See `example/04-llm-planner` for a runnable walkthrough.
 
 ## Creating Custom Planners
 
-### Basic Custom Planner
+Implement `agent.Planner`:
 
 ```go
 type MyPlanner struct {
-    rules []Rule
+    // ...
 }
 
 func (p *MyPlanner) Plan(ctx context.Context, req agent.PlanRequest) (agent.Decision, error) {
-    // Apply rules in order
-    for _, rule := range p.rules {
-        if decision, ok := rule.Apply(req); ok {
-            return decision, nil
-        }
+    if req.CurrentState == agent.StateIntake {
+        return agent.NewTransitionDecision(agent.StateExplore, "starting"), nil
     }
-
-    // Default behavior
-    return agent.NewFailDecision("no applicable rule"), nil
+    if len(req.Evidence) > 5 {
+        return agent.NewTransitionDecision(agent.StateDecide, "enough info"), nil
+    }
+    if req.CurrentState == agent.StateDecide {
+        return agent.NewFinishDecision("done", nil), nil
+    }
+    return agent.NewCallToolDecision("gather_more", nil, "need more"), nil
 }
 ```
 
 ### Composite Planner
 
-Combine multiple planners:
-
 ```go
 type CompositeP struct {
-    primary   agent.Planner
-    fallback  agent.Planner
+    primary  agent.Planner
+    fallback agent.Planner
 }
 
 func (p *CompositeP) Plan(ctx context.Context, req agent.PlanRequest) (agent.Decision, error) {
     decision, err := p.primary.Plan(ctx, req)
     if err != nil {
-        // Fall back to secondary planner
         return p.fallback.Plan(ctx, req)
     }
     return decision, nil
 }
 ```
 
-### Caching Planner
-
-Add caching to any planner:
-
-```go
-type CachingPlanner struct {
-    inner agent.Planner
-    cache map[string]agent.Decision
-}
-
-func (p *CachingPlanner) Plan(ctx context.Context, req agent.PlanRequest) (agent.Decision, error) {
-    key := computeCacheKey(req)
-    if cached, ok := p.cache[key]; ok {
-        return cached, nil
-    }
-
-    decision, err := p.inner.Plan(ctx, req)
-    if err == nil {
-        p.cache[key] = decision
-    }
-    return decision, err
-}
-```
+Or use `agent.NewHybridPlanner` when the primary path is rule-based.
 
 ## Planner Guarantees
 
@@ -282,37 +227,37 @@ For testing, planners must support deterministic behavior (e.g., ScriptedPlanner
 
 ### 1. Test with ScriptedPlanner
 
-Always test your agent with deterministic planners first:
-
 ```go
 func TestAgentBehavior(t *testing.T) {
     planner := agent.NewScriptedPlanner(expectedSteps...)
 
-    engine, _ := agent.New(
+    engine, err := agent.New(
         agent.WithPlanner(planner),
-        agent.WithTools(tools...),
+        agent.WithTool(readTool),
+        agent.WithTool(writeTool),
     )
+    require.NoError(t, err)
 
     run, err := engine.Run(ctx, "test goal")
-    assert.NoError(t, err)
-    assert.Equal(t, agent.StatusDone, run.Status)
+    require.NoError(t, err)
+    assert.Equal(t, agent.StatusCompleted, run.Status)
 }
 ```
 
 ### 2. Separate Planning from Execution
 
-Don't let planners access tools directly:
+Don't let planners access tools or I/O directly:
 
 ```go
 // Good - planner only decides
-func (p *MyPlanner) Plan(ctx context.Context, req PlanRequest) (Decision, error) {
-    return NewCallToolDecision("read_file", input, "need info"), nil
+func (p *MyPlanner) Plan(ctx context.Context, req agent.PlanRequest) (agent.Decision, error) {
+    return agent.NewCallToolDecision("read_file", input, "need info"), nil
 }
 
 // Bad - planner executes (violates separation)
-func (p *BadPlanner) Plan(ctx context.Context, req PlanRequest) (Decision, error) {
-    content, _ := os.ReadFile(path)  // Don't do this!
-    return NewFinishDecision("done", content), nil
+func (p *BadPlanner) Plan(ctx context.Context, req agent.PlanRequest) (agent.Decision, error) {
+    content, _ := os.ReadFile(path) // Don't do this!
+    return agent.NewFinishDecision("done", content), nil
 }
 ```
 
@@ -322,43 +267,18 @@ Always provide a reason for decisions:
 
 ```go
 // Good - explains why
-NewCallToolDecision("delete_file", input, "file is temporary and task complete")
+agent.NewCallToolDecision("delete_file", input, "file is temporary and task complete")
 
 // Bad - no context
-NewCallToolDecision("delete_file", input, "")
+agent.NewCallToolDecision("delete_file", input, "")
 ```
 
-### 4. Respect Allowed Tools
+### 4. Respect Allowed Tools and Budgets
 
-Only suggest tools from `AllowedTools`:
-
-```go
-func (p *MyPlanner) Plan(ctx context.Context, req PlanRequest) (Decision, error) {
-    // Check if desired tool is allowed
-    for _, allowed := range req.AllowedTools {
-        if allowed == "write_file" {
-            return NewCallToolDecision("write_file", input, "updating"), nil
-        }
-    }
-    // Tool not available in current state
-    return NewTransitionDecision(StateAct, "need write access"), nil
-}
-```
-
-### 5. Handle Budget Exhaustion
-
-Check budgets before making decisions:
-
-```go
-func (p *MyPlanner) Plan(ctx context.Context, req PlanRequest) (Decision, error) {
-    if remaining, ok := req.Budgets["tool_calls"]; ok && remaining <= 0 {
-        return NewFailDecision("budget exhausted"), nil
-    }
-    // Continue normal planning...
-}
-```
+Only choose tools from `req.AllowedTools`, and check `req.Budgets` before long tool loops.
 
 ## Next Steps
 
-- [Policies](policies.md) - Enforcing limits on planner decisions
-- [Integration Guides](../integrations/) - Setting up LLM providers
+- [Policies](policies.md) - Budgets, approvals, eligibility
+- [Tools](tools.md) - Creating tools with annotations
+- [States](states.md) - The canonical state machine

--- a/docs/concepts/policies.md
+++ b/docs/concepts/policies.md
@@ -302,5 +302,6 @@ func TestBudgetEnforcement(t *testing.T) {
 
 ## Next Steps
 
-- [Evidence](evidence.md) - How agents accumulate knowledge
-- [Ledger](ledger.md) - Audit trail for all operations
+- [States](states.md) - The canonical state machine
+- [Tools](tools.md) - Annotations that drive approval and risk
+- [Planners](planners.md) - Decisions that policies constrain

--- a/docs/concepts/policies.md
+++ b/docs/concepts/policies.md
@@ -36,15 +36,17 @@ Budgets set hard limits on resource consumption.
 ```go
 engine, _ := agent.New(
     agent.WithBudget("tool_calls", 100),  // Max 100 tool calls
-    agent.WithBudget("tokens", 50000),     // Max 50k tokens
+    agent.WithBudget("tokens", 50000),     // Named budget (consume via middleware)
 )
 ```
+
+The engine automatically consumes the `tool_calls` budget on each successful tool execution. Other named budgets are available to planners via `PlanRequest.Budgets` and can be decremented with `BudgetFromContextMiddleware` in the middleware chain.
 
 ### How Budgets Work
 
 1. Each run starts with the configured budget
-2. Every tool call decrements the relevant budget
-3. When a budget hits zero, the engine stops
+2. Every successful tool call decrements `tool_calls` (when configured)
+3. When a budget cannot cover the next call, the engine stops
 4. Planners see remaining budgets in `PlanRequest.Budgets`
 
 ### Budget Exhaustion
@@ -53,28 +55,8 @@ When a budget is exhausted:
 
 ```go
 run, err := engine.Run(ctx, "Process all files")
-// err == nil, but:
+// err is policy.ErrBudgetExceeded (wrapped)
 // run.Status == agent.StatusFailed
-// run.FailureReason == "budget exhausted: tool_calls"
-```
-
-### Custom Budget Types
-
-Define domain-specific budgets:
-
-```go
-engine, _ := agent.New(
-    agent.WithBudget("api_calls", 50),      // Limit API requests
-    agent.WithBudget("database_queries", 20), // Limit DB access
-    agent.WithBudget("llm_tokens", 10000),   // Limit LLM usage
-)
-
-// Decrement in tool handler
-func apiHandler(ctx context.Context, input json.RawMessage) (tool.Result, error) {
-    budget := agent.BudgetFromContext(ctx)
-    budget.Decrement("api_calls", 1)
-    // ...
-}
 ```
 
 ### Budget Visibility
@@ -82,11 +64,11 @@ func apiHandler(ctx context.Context, input json.RawMessage) (tool.Result, error)
 Planners can see remaining budgets:
 
 ```go
-func (p *MyPlanner) Plan(ctx context.Context, req PlanRequest) (Decision, error) {
+func (p *MyPlanner) Plan(ctx context.Context, req agent.PlanRequest) (agent.Decision, error) {
     remaining := req.Budgets["tool_calls"]
     if remaining < 5 {
-        // Running low, wrap up
-        return NewFinishDecision("completing due to budget", result), nil
+        // Running low, wrap up — Finish is valid from decide/validate
+        return agent.NewFinishDecision("completing due to budget", result), nil
     }
     // Continue normal operation
 }
@@ -99,9 +81,7 @@ Approvals require human sign-off before executing risky operations.
 ### Setting Up Approval
 
 ```go
-// Create an approver
-approver := agent.NewCallbackApprover(func(ctx context.Context, req ApprovalRequest) (bool, error) {
-    // Show to user
+approver := agent.NewCallbackApprover(func(ctx context.Context, req agent.ApprovalRequest) (bool, error) {
     fmt.Printf("Approve %s with input %s? [y/n]: ", req.ToolName, req.Input)
     var response string
     fmt.Scanln(&response)
@@ -115,35 +95,21 @@ engine, _ := agent.New(
 
 ### What Triggers Approval
 
-By default, approval is required for:
+By default (via tool annotations), approval is required when a tool's annotations say so — typically:
 
 1. Tools marked `Destructive: true`
-2. Tools with `RiskLevel: RiskHigh` or `RiskLevel: RiskCritical`
-
-### Custom Approval Rules
-
-```go
-approver := agent.NewConditionalApprover(
-    // Always approve read-only tools
-    agent.ApproveIf(func(req ApprovalRequest) bool {
-        return req.Tool.Annotations().ReadOnly
-    }),
-    // Require approval for specific tools
-    agent.RequireApprovalFor("delete_file", "drop_table", "send_email"),
-    // Require approval above risk threshold
-    agent.RequireApprovalAboveRisk(agent.RiskMedium),
-)
-```
+2. Tools with high / critical risk levels (`ShouldRequireApproval()`)
 
 ### Approval Request Structure
 
 ```go
 type ApprovalRequest struct {
-    RunID    string          // Current run
-    Tool     tool.Tool       // Tool being called
-    Input    json.RawMessage // Input to the tool
-    State    agent.State     // Current state
-    Evidence []Evidence      // Accumulated evidence
+    RunID     string
+    ToolName  string
+    Input     json.RawMessage
+    Reason    string
+    RiskLevel string
+    Timestamp time.Time
 }
 ```
 
@@ -157,7 +123,7 @@ engine, _ := agent.New(
 
 // Or auto-deny everything
 engine, _ := agent.New(
-    agent.WithApprover(agent.DenyAllApprover()),
+    agent.WithApprover(agent.DenyApprover("denied in test")),
 )
 ```
 
@@ -171,15 +137,25 @@ Eligibility controls which tools are available in each state.
 eligibility := agent.NewToolEligibility()
 
 // Read-only tools in explore and validate
-eligibility.Allow(agent.StateExplore, "read_file", "list_dir", "search")
-eligibility.Allow(agent.StateValidate, "read_file", "verify_result")
+eligibility.AllowMultiple(agent.StateExplore, "read_file", "list_dir", "search")
+eligibility.AllowMultiple(agent.StateValidate, "read_file", "verify_result")
 
 // Destructive tools only in act
-eligibility.Allow(agent.StateAct, "write_file", "delete_file", "execute")
+eligibility.AllowMultiple(agent.StateAct, "write_file", "delete_file", "execute")
 
 engine, _ := agent.New(
     agent.WithToolEligibility(eligibility),
 )
+```
+
+Declarative form:
+
+```go
+eligibility := agent.NewToolEligibilityWith(agent.EligibilityRules{
+    agent.StateExplore:  {"read_file", "list_dir"},
+    agent.StateAct:      {"write_file", "delete_file"},
+    agent.StateValidate: {"read_file"},
+})
 ```
 
 ### How Eligibility Works
@@ -194,39 +170,24 @@ If a planner tries to call an ineligible tool:
 
 ```go
 // Planner requests write_file in explore state
-decision := NewCallToolDecision("write_file", input, "writing")
+decision := agent.NewCallToolDecision("write_file", input, "writing")
 
-// Engine rejects it
-// run.FailureReason == "tool write_file not eligible in state explore"
+// Engine rejects it — run ends failed
+// run.Status == agent.StatusFailed
+// error / message mentions the tool is not allowed in the current state
 ```
 
 ### Default Eligibility
 
-If no eligibility is configured, the engine uses sensible defaults:
+If you omit `WithToolEligibility`, the engine uses `NewDefaultToolEligibility()`:
 
 ```go
-// Default: ReadOnly tools in explore/validate, all tools in act
-defaultEligibility := agent.DefaultToolEligibility()
+// Wildcard allow in explore / decide / act / validate.
+// Intake and terminal states still deny tools.
+eligibility := agent.NewDefaultToolEligibility()
 ```
 
-### Dynamic Eligibility
-
-Eligibility can depend on runtime context:
-
-```go
-eligibility := agent.NewDynamicEligibility(func(state agent.State, tool tool.Tool) bool {
-    // Allow all tools if user is admin
-    if isAdmin := agent.VarFromContext(ctx, "is_admin"); isAdmin == true {
-        return true
-    }
-
-    // Normal eligibility rules
-    if state == agent.StateExplore {
-        return tool.Annotations().ReadOnly
-    }
-    return true
-})
-```
+Prefer an explicit allow-list in production. Pass `agent.NewToolEligibility()` (empty) for deny-by-default.
 
 ## Combining Policies
 
@@ -236,7 +197,6 @@ Policies work together to create layered protection:
 engine, _ := agent.New(
     // Layer 1: Hard budget limits
     agent.WithBudget("tool_calls", 50),
-    agent.WithBudget("tokens", 10000),
 
     // Layer 2: State-based tool restrictions
     agent.WithToolEligibility(eligibility),
@@ -248,28 +208,40 @@ engine, _ := agent.New(
 
 ### Enforcement Order
 
-1. **Eligibility Check**: Is the tool allowed in this state?
-2. **Budget Check**: Is there remaining budget?
-3. **Approval Check**: Does this tool require approval?
-4. **Execution**: Tool runs only if all checks pass
+1. **Structural act-gate**: Side-effecting tools only in states that allow side effects (`act`)
+2. **Eligibility check**: Is the tool allowed in this state?
+3. **Governance / budget**: Can the call proceed under remaining budget?
+4. **Approval**: Does this tool require approval?
+5. **Execution**: Tool runs only if all checks pass
 
 ## Policy Events
 
-Monitor policy enforcement:
+Watch policy outcomes through the event stream (requires `WithEventStore`):
 
 ```go
-engine, _ := agent.New(
-    agent.WithPolicyEventHandler(func(event PolicyEvent) {
-        switch event.Type {
-        case PolicyEventBudgetExhausted:
-            log.Warn("Budget exhausted", "budget", event.Budget)
-        case PolicyEventApprovalDenied:
-            log.Warn("Approval denied", "tool", event.Tool)
-        case PolicyEventEligibilityDenied:
-            log.Warn("Tool not eligible", "tool", event.Tool, "state", event.State)
-        }
-    }),
+import (
+    "go.klarlabs.de/agent/domain/event"
+    "go.klarlabs.de/agent/infrastructure/storage/memory"
 )
+
+store := memory.NewEventStore()
+engine, _ := agent.New(
+    agent.WithPlanner(planner),
+    agent.WithEventStore(store),
+    // ...
+)
+
+runID, events, _ := engine.Stream(ctx, "Process files")
+for evt := range events {
+    switch evt.Type {
+    case event.TypeBudgetExhausted:
+        log.Warn("budget exhausted", "run", runID)
+    case event.TypeApprovalDenied:
+        log.Warn("approval denied", "run", runID)
+    case event.TypeToolFailed:
+        log.Warn("tool failed", "run", runID, "payload", evt.Payload)
+    }
+}
 ```
 
 ## Best Practices
@@ -279,22 +251,19 @@ engine, _ := agent.New(
 Begin with tight limits and loosen as needed:
 
 ```go
-// Start tight
 agent.WithBudget("tool_calls", 10),
-
 // Expand after testing
 agent.WithBudget("tool_calls", 100),
 ```
 
-### 2. Use Multiple Budget Types
-
-Don't rely on a single budget:
+### 2. Prefer Explicit Eligibility
 
 ```go
-// Multiple safeguards
-agent.WithBudget("tool_calls", 100),    // Overall limit
-agent.WithBudget("write_ops", 10),       // Limit writes specifically
-agent.WithBudget("api_calls", 50),       // Limit external calls
+eligibility := agent.NewToolEligibilityWith(agent.EligibilityRules{
+    agent.StateExplore:  {"read_file", "list_dir"},
+    agent.StateAct:      {"write_file"},
+    agent.StateValidate: {"read_file"},
+})
 ```
 
 ### 3. Separate by Risk
@@ -302,47 +271,32 @@ agent.WithBudget("api_calls", 50),       // Limit external calls
 Different tools deserve different treatment:
 
 ```go
-// Low risk: broadly available
-eligibility.Allow(agent.StateExplore, lowRiskTools...)
-eligibility.Allow(agent.StateValidate, lowRiskTools...)
-eligibility.Allow(agent.StateAct, lowRiskTools...)
-
-// High risk: only in act with approval
-eligibility.Allow(agent.StateAct, highRiskTools...)
-// Plus approval requirement via annotations
+eligibility.AllowMultiple(agent.StateExplore, lowRiskTools...)
+eligibility.AllowMultiple(agent.StateValidate, lowRiskTools...)
+eligibility.AllowMultiple(agent.StateAct, lowRiskTools...)
+eligibility.AllowMultiple(agent.StateAct, highRiskTools...)
+// High-risk / destructive tools still go through approval via annotations
 ```
 
-### 4. Log Policy Decisions
+### 4. Observe via Events
 
-Make policy enforcement visible:
-
-```go
-agent.WithPolicyEventHandler(func(event PolicyEvent) {
-    logger.Info("policy decision",
-        "type", event.Type,
-        "tool", event.Tool,
-        "state", event.State,
-        "allowed", event.Allowed,
-    )
-})
-```
+Prefer `Stream` / `EventStore` over ad-hoc hooks so policy decisions land in the same audit trail as the rest of the run.
 
 ### 5. Test Policy Boundaries
-
-Verify policies work as expected:
 
 ```go
 func TestBudgetEnforcement(t *testing.T) {
     engine, _ := agent.New(
         agent.WithBudget("tool_calls", 2),
         agent.WithPlanner(plannerThatCallsToolsForever),
+        agent.WithTool(readTool),
     )
 
-    run, _ := engine.Run(ctx, "test")
+    run, err := engine.Run(ctx, "test")
 
+    assert.ErrorIs(t, err, policy.ErrBudgetExceeded)
     assert.Equal(t, agent.StatusFailed, run.Status)
-    assert.Contains(t, run.FailureReason, "budget exhausted")
-    assert.Equal(t, 2, run.StepCount)  // Stopped at limit
+    assert.Equal(t, 2, run.ConsumedToolCalls())
 }
 ```
 

--- a/docs/concepts/states.md
+++ b/docs/concepts/states.md
@@ -212,10 +212,10 @@ if err != nil {
 }
 
 switch run.Status {
-case agent.StatusDone:
+case agent.StatusCompleted:
     fmt.Println("Success:", run.Result)
 case agent.StatusFailed:
-    fmt.Println("Agent failed:", run.FailureReason)
+    fmt.Println("Agent failed:", run.Error)
 }
 ```
 

--- a/interfaces/api/builders.go
+++ b/interfaces/api/builders.go
@@ -204,6 +204,12 @@ func NewFailDecision(reason string, err error) Decision {
 	return agent.NewFailDecision(reason, err)
 }
 
+// NewAskHumanDecision creates a decision to pause and ask for human input.
+// Resume with Engine.ResumeWithInput after the operator answers.
+func NewAskHumanDecision(question string, options ...string) Decision {
+	return agent.NewAskHumanDecision(question, options...)
+}
+
 // AutoApprover returns an approver that automatically approves all requests.
 // This is a convenience function for development and testing.
 func AutoApprover() policy.Approver {

--- a/interfaces/api/builders_test.go
+++ b/interfaces/api/builders_test.go
@@ -275,6 +275,24 @@ func TestDecisionConstructors(t *testing.T) {
 			t.Errorf("Reason = %v, want failed", d.Fail.Reason)
 		}
 	})
+
+	t.Run("NewAskHumanDecision", func(t *testing.T) {
+		t.Parallel()
+
+		d := api.NewAskHumanDecision("Proceed?", "yes", "no")
+		if d.Type != agent.DecisionAskHuman {
+			t.Errorf("Type = %v, want ask_human", d.Type)
+		}
+		if d.AskHuman == nil {
+			t.Fatal("AskHuman is nil")
+		}
+		if d.AskHuman.Question != "Proceed?" {
+			t.Errorf("Question = %v, want Proceed?", d.AskHuman.Question)
+		}
+		if len(d.AskHuman.Options) != 2 {
+			t.Errorf("Options len = %d, want 2", len(d.AskHuman.Options))
+		}
+	})
 }
 
 func TestNewCallbackApprover(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@
 package agentgo
 
 // Version is the current version of agent-go.
-const Version = "0.15.0"
+const Version = "0.16.0"
 
 // GetVersion returns the current version string.
 func GetVersion() string {

--- a/version_test.go
+++ b/version_test.go
@@ -10,8 +10,8 @@ func TestVersion(t *testing.T) {
 	}
 
 	// Verify version matches the current release line
-	if Version != "0.15.0" {
-		t.Errorf("Version is %s, expected 0.15.0", Version)
+	if Version != "0.16.0" {
+		t.Errorf("Version is %s, expected 0.16.0", Version)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Concept-doc polish plus **v0.16.0 release prep**.

### Docs / API polish
- Align `docs/concepts/{policies,planners,states,README}` with the real public API
- Export `NewAskHumanDecision` from `interfaces/api`

### Release prep
- Bump `agentgo.Version` → `0.16.0`
- Refresh `CHANGELOG.md` for work since `v0.15.0` (onboarding path, trust hardening, stub packs, sandbox, API seal)

## After merge

Push tag `v0.16.0` on `main` to trigger `.github/workflows/release.yml` (tests + GitHub Release + pkg.go.dev ping).

```bash
git checkout main && git pull
git tag -a v0.16.0 -m "v0.16.0"
git push origin v0.16.0
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a004c3-0d63-7667-8815-db3304a4e158?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a004c3-0d63-7667-8815-db3304a4e158&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

