### PR TITLE
feat: soft-reject Finish/Fail, API seal stores/delegate, docs + Actions polish

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -53,7 +53,7 @@ jobs:
       any: ${{ steps.select.outputs.any }}
       count: ${{ steps.select.outputs.count }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - id: select
@@ -125,8 +125,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
           cache: true
@@ -150,8 +150,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
           cache: true
@@ -177,8 +177,8 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
           cache: true
@@ -192,7 +192,7 @@ jobs:
             ./infrastructure/planner/... \
             | tee bench-results.txt
       - name: Upload benchmark results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: benchmark-results
           path: bench-results.txt

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -25,10 +25,10 @@ jobs:
         working-directory: ./website-astro
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "20"
           cache: npm
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'
           cache: true
@@ -56,7 +56,7 @@ jobs:
           git diff --exit-code go.mod go.sum
 
       - name: Create Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           generate_release_notes: true
           draft: false
@@ -69,10 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `state.transition.rejected` event when Transition/Finish/Fail targets a
+  disallowed state (soft-reject path).
+- Public API constructors: `NewEventStore`, `NewRunStore`, `NewArtifactStore`,
+  `NewDelegateTool`, `NewExecutorWithOptions` (+ executor option helpers).
+
+### Fixed
+- Soft-reject Finish/Fail when `done`/`failed` is not reachable from the current
+  state (planner receives Feedback; run continues under loop detection).
+- Concept `states.md` transition table matches `DefaultTransitions`.
+- Regenerated `docs/api/*` from godoc; Actions pins bumped to Node 24 majors.
+
 ## [0.16.0] - 2026-08-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,10 +237,10 @@ Configured via `resilience.Executor`:
 
 ### Event Streaming
 
-The engine publishes 21 event types to an optional EventStore:
+The engine publishes 22 event types to an optional EventStore:
 
 - **Run lifecycle**: `run.started`, `run.completed`, `run.failed`, `run.paused`, `run.resumed`
-- **State machine**: `state.transitioned`
+- **State machine**: `state.transitioned`, `state.transition.rejected`
 - **Tool execution**: `tool.called`, `tool.succeeded`, `tool.failed`
 - **Decisions**: `planner.proposed`, `decision.made`
 - **Policy**: `approval.requested`, `approval.granted`, `approval.denied`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ agent-go is more than a single-agent engine — it's a **policy-aware, event-dri
 |-----------|-------------|
 | **Multi-agent coordination** | DelegateTool wraps child engines as tools. TaskContext shares state across agent hierarchies. |
 | **Agent protocol** | Message envelope with correlation IDs, capability discovery, trust boundaries, request-reply and broadcast patterns. |
-| **Event streaming** | `Stream()` returns a real-time channel of 21 event types. Powers dashboards, debugging, and orchestration. |
+| **Event streaming** | `Stream()` returns a real-time channel of 22 event types. Powers dashboards, debugging, and orchestration. |
 | **MCP integration** | Expose tools via Model Context Protocol with full policy enforcement (approval, budgets, audit trail). |
 | **Replay and fork** | Replay historical runs from events. Fork runs at any step for simulation and testing. |
 | **Shared memory** | Cross-agent TaskContext with thread-safe shared variables, evidence, and artifact references. |

--- a/application/engine.go
+++ b/application/engine.go
@@ -1032,14 +1032,7 @@ func (e *Engine) executeTransition(ctx context.Context, interp *statemachine.Int
 		// planner self-corrects on the next step (and loop detection bounds
 		// repeated rejections). Other errors fail the run.
 		if errors.Is(err, agent.ErrTransitionRejected) {
-			allowed := e.transitions.AllowedTransitions(machineCtx.Run.CurrentState)
-			machineCtx.Feedback = fmt.Sprintf(
-				"Your transition to %q was rejected. You are still in state %q. Valid transitions from here are: %v. Choose one of those, or call an allowed tool.",
-				decision.ToState, machineCtx.Run.CurrentState, allowed)
-			e.logger.Info().
-				Add(logging.RunID(machineCtx.Run.ID)).
-				Add(logging.State(machineCtx.Run.CurrentState)).
-				Msg("transition rejected; feeding back to planner")
+			e.softRejectTransition(ctx, machineCtx, decision.ToState, decision.Reason)
 			return nil
 		}
 		return err
@@ -1048,6 +1041,25 @@ func (e *Engine) executeTransition(ctx context.Context, interp *statemachine.Int
 		FromState: fromState, ToState: decision.ToState, Reason: decision.Reason,
 	}, machineCtx)
 	return nil
+}
+
+// softRejectTransition records planner feedback and an audit event when a
+// Transition/Finish/Fail targets a state that policy or the machine rejects.
+func (e *Engine) softRejectTransition(ctx context.Context, machineCtx *statemachine.Context, attempted agent.State, reason string) {
+	allowed := e.transitions.AllowedTransitions(machineCtx.Run.CurrentState)
+	machineCtx.Feedback = fmt.Sprintf(
+		"Your transition to %q was rejected. You are still in state %q. Valid transitions from here are: %v. Choose one of those, or call an allowed tool.",
+		attempted, machineCtx.Run.CurrentState, allowed)
+	e.logger.Info().
+		Add(logging.RunID(machineCtx.Run.ID)).
+		Add(logging.State(machineCtx.Run.CurrentState)).
+		Msg("transition rejected; feeding back to planner")
+	e.publishEvent(ctx, machineCtx.Run.ID, event.TypeStateTransitionRejected, event.StateTransitionRejectedPayload{
+		FromState: machineCtx.Run.CurrentState,
+		Attempted: attempted,
+		Reason:    reason,
+		Allowed:   allowed,
+	}, machineCtx)
 }
 
 // executeAskHuman handles human input requests by pausing the run.
@@ -1072,10 +1084,16 @@ func (e *Engine) executeAskHuman(_ context.Context, _ *statemachine.Interpreter,
 }
 
 // executeFinish completes the run successfully.
-func (e *Engine) executeFinish(_ context.Context, interp *statemachine.Interpreter, machineCtx *statemachine.Context, decision *agent.FinishDecision) error {
+func (e *Engine) executeFinish(ctx context.Context, interp *statemachine.Interpreter, machineCtx *statemachine.Context, decision *agent.FinishDecision) error {
 	run := machineCtx.Run
 	// Transition first, then mark complete (order matters - transition checks current state)
 	if err := interp.Transition(agent.StateDone, decision.Summary); err != nil {
+		// Finish from a state that cannot reach done (e.g. explore) is soft-rejected
+		// so the planner can transition to decide/validate first.
+		if errors.Is(err, agent.ErrTransitionRejected) {
+			e.softRejectTransition(ctx, machineCtx, agent.StateDone, decision.Summary)
+			return nil
+		}
 		return err
 	}
 	run.Result = decision.Result
@@ -1087,10 +1105,14 @@ func (e *Engine) executeFinish(_ context.Context, interp *statemachine.Interpret
 }
 
 // executeFail terminates the run with failure.
-func (e *Engine) executeFail(_ context.Context, interp *statemachine.Interpreter, machineCtx *statemachine.Context, decision *agent.FailDecision) error {
+func (e *Engine) executeFail(ctx context.Context, interp *statemachine.Interpreter, machineCtx *statemachine.Context, decision *agent.FailDecision) error {
 	run := machineCtx.Run
 	// Transition first, then mark failed (order matters - transition checks current state)
 	if err := interp.Transition(agent.StateFailed, decision.Reason); err != nil {
+		if errors.Is(err, agent.ErrTransitionRejected) {
+			e.softRejectTransition(ctx, machineCtx, agent.StateFailed, decision.Reason)
+			return nil
+		}
 		return err
 	}
 	run.Error = decision.Reason

--- a/application/engine_test.go
+++ b/application/engine_test.go
@@ -572,16 +572,16 @@ func (p *selfCorrectPlanner) Plan(_ context.Context, req planner.PlanRequest) (a
 	}
 }
 
-func TestRun_TransitionRejection_FeedbackAndSelfCorrect(t *testing.T) {
-	// A rejected transition is recoverable: the engine feeds it back, the planner
-	// sees it and chooses a valid transition, and the run completes.
-	p := &selfCorrectPlanner{}
+func TestRun_FinishFromExplore_SoftRejectedThenSelfCorrect(t *testing.T) {
+	// Finish is only valid from decide/validate under DefaultTransitions.
+	// Soft-reject + feedback lets the planner recover instead of failing the run.
+	p := &finishThenSelfCorrectPlanner{}
 	engine, err := NewEngine(EngineConfig{Registry: newTestRegistry(), Planner: p})
 	if err != nil {
 		t.Fatalf("new engine: %v", err)
 	}
 
-	run, runErr := engine.Run(context.Background(), "self-correct")
+	run, runErr := engine.Run(context.Background(), "finish-self-correct")
 	if runErr != nil {
 		t.Fatalf("expected recovery, got error: %v", runErr)
 	}
@@ -589,7 +589,33 @@ func TestRun_TransitionRejection_FeedbackAndSelfCorrect(t *testing.T) {
 		t.Errorf("expected completed, got %s", run.Status)
 	}
 	if !p.sawFeedback {
-		t.Error("planner did not receive feedback after the rejected transition")
+		t.Error("planner did not receive feedback after rejected Finish")
+	}
+}
+
+type finishThenSelfCorrectPlanner struct {
+	step        int
+	sawFeedback bool
+}
+
+func (p *finishThenSelfCorrectPlanner) Plan(_ context.Context, req planner.PlanRequest) (agent.Decision, error) {
+	if req.Feedback != "" {
+		p.sawFeedback = true
+	}
+	p.step++
+	switch req.CurrentState {
+	case agent.StateIntake:
+		return agent.NewTransitionDecision(agent.StateExplore, "start"), nil
+	case agent.StateExplore:
+		if !p.sawFeedback {
+			// Illegal Finish — should soft-reject
+			return agent.NewFinishDecision("too early", nil), nil
+		}
+		return agent.NewTransitionDecision(agent.StateDecide, "go decide"), nil
+	case agent.StateDecide:
+		return agent.NewFinishDecision("done", nil), nil
+	default:
+		return agent.NewFailDecision("unexpected", nil), nil
 	}
 }
 

--- a/application/engine_test.go
+++ b/application/engine_test.go
@@ -572,6 +572,27 @@ func (p *selfCorrectPlanner) Plan(_ context.Context, req planner.PlanRequest) (a
 	}
 }
 
+func TestRun_TransitionRejection_FeedbackAndSelfCorrect(t *testing.T) {
+	// A rejected transition is recoverable: the engine feeds it back, the planner
+	// sees it and chooses a valid transition, and the run completes.
+	p := &selfCorrectPlanner{}
+	engine, err := NewEngine(EngineConfig{Registry: newTestRegistry(), Planner: p})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+
+	run, runErr := engine.Run(context.Background(), "self-correct")
+	if runErr != nil {
+		t.Fatalf("expected recovery, got error: %v", runErr)
+	}
+	if run.Status != agent.RunStatusCompleted {
+		t.Errorf("expected completed, got %s", run.Status)
+	}
+	if !p.sawFeedback {
+		t.Error("planner did not receive feedback after the rejected transition")
+	}
+}
+
 func TestRun_FinishFromExplore_SoftRejectedThenSelfCorrect(t *testing.T) {
 	// Finish is only valid from decide/validate under DefaultTransitions.
 	// Soft-reject + feedback lets the planner recover instead of failing the run.

--- a/docs/api/agent.md
+++ b/docs/api/agent.md
@@ -36,6 +36,27 @@ var (
 	// ErrAwaitingHumanInput indicates the run is paused awaiting human input.
 	ErrAwaitingHumanInput = errors.New("run is awaiting human input")
 
+	// ErrNoProgress indicates the run was aborted by loop detection: too many
+	// consecutive steps made no progress (no state change and no new evidence),
+	// e.g. the planner kept emitting self-transitions or repeats.
+	ErrNoProgress = errors.New("run aborted: no progress (possible loop)")
+
+	// ErrMaxSteps indicates the run was aborted because it reached MaxSteps
+	// without entering a terminal state.
+	ErrMaxSteps = errors.New("max steps exceeded")
+
+	// ErrAuditFailed indicates a configured EventStore or RunStore failed to
+	// persist an audit record. When strict audit is enabled (default whenever
+	// an EventStore is configured), this fails the run rather than silently
+	// dropping the audit trail.
+	ErrAuditFailed = errors.New("audit persistence failed")
+
+	// ErrTransitionRejected indicates a requested transition did not fire: the
+	// policy disallows it, or the state machine has no matching edge from the
+	// current state. The engine surfaces this to the planner as feedback rather
+	// than letting it become a silent no-op.
+	ErrTransitionRejected = errors.New("transition rejected")
+
 	// ErrNoPendingQuestion indicates no pending question exists for human input.
 	ErrNoPendingQuestion = errors.New("run does not have a pending question")
 
@@ -49,7 +70,8 @@ var (
 	ErrCustomStateDuplicate = errors.New("custom state already registered")
 
 	// ErrCustomSideEffectsForbidden indicates a custom state attempted to opt into
-	// side effects. Only the canonical act state may allow side-effecting tools.
+	// side effects. Only the canonical act state may allow side-effecting tools
+	// (design invariant: state semantics).
 	ErrCustomSideEffectsForbidden = errors.New("custom states cannot allow side effects; only act may")
 )
     Domain errors for the agent runtime.
@@ -75,7 +97,7 @@ type CustomState struct {
 	Name State
 
 	// AllowsSideEffects must be false. Only the canonical act state may permit
-	// side-effecting tools; Register rejects true.
+	// side-effecting tools (invariant 5). Register rejects true.
 	AllowsSideEffects bool
 
 	// Terminal indicates whether this is a terminal (final) state.
@@ -132,13 +154,27 @@ type Evidence struct {
     Evidence represents an observation or result accumulated during a run.
 
 func NewHumanEvidence(content json.RawMessage) Evidence
-    NewHumanEvidence creates evidence from human input.
+    NewHumanEvidence creates evidence from human input, stamping the wall clock.
+    The engine uses NewHumanEvidenceAt with an injected clock for determinism.
+
+func NewHumanEvidenceAt(content json.RawMessage, t time.Time) Evidence
+    NewHumanEvidenceAt creates evidence from human input at the given instant.
 
 func NewSystemEvidence(note string) Evidence
-    NewSystemEvidence creates system-generated evidence.
+    NewSystemEvidence creates system-generated evidence, stamping the wall
+    clock. The engine uses NewSystemEvidenceAt with an injected clock for
+    determinism.
+
+func NewSystemEvidenceAt(note string, t time.Time) Evidence
+    NewSystemEvidenceAt creates system-generated evidence at the given instant.
 
 func NewToolEvidence(toolName string, content json.RawMessage) Evidence
-    NewToolEvidence creates evidence from a tool result.
+    NewToolEvidence creates evidence from a tool result, stamping the wall
+    clock. The engine uses NewToolEvidenceAt with an injected clock for
+    determinism.
+
+func NewToolEvidenceAt(toolName string, content json.RawMessage, t time.Time) Evidence
+    NewToolEvidenceAt creates evidence from a tool result at the given instant.
 
 type EvidenceType string
     EvidenceType classifies the source of evidence.
@@ -179,6 +215,14 @@ type Run struct {
 	Result          json.RawMessage  `json:"result,omitempty"`
 	Error           string           `json:"error,omitempty"`
 	PendingQuestion *PendingQuestion `json:"pending_question,omitempty"`
+	ParentRunID     string           `json:"parent_run_id,omitempty"`
+	TaskID          string           `json:"task_id,omitempty"`
+	// GovernanceEvidence persists the run's axi evidence-chain snapshot across
+	// a human-input pause so the resumed run continues ONE continuous,
+	// tamper-evident chain rather than starting a fresh one. It is opaque to
+	// the domain (an axi SessionSnapshot); only the full-delegation governor
+	// reads and writes it. Empty when no governor exposes an evidence chain.
+	GovernanceEvidence json.RawMessage `json:"governance_evidence,omitempty"`
 }
     Run represents a single execution of the agent. It is the aggregate root for
     the agent domain.
@@ -190,19 +234,41 @@ func (r *Run) AddEvidence(e Evidence)
     AddEvidence appends evidence to the run.
 
 func (r *Run) AskHuman(question string, options []string)
-    AskHuman sets a pending question and pauses the run.
+    AskHuman sets a pending question and pauses the run, stamping AskedAt from
+    the wall clock. The engine uses AskHumanAt with an injected clock.
+
+func (r *Run) AskHumanAt(question string, options []string, t time.Time)
+    AskHumanAt sets a pending question and pauses the run at the given instant.
 
 func (r *Run) ClearPendingQuestion()
     ClearPendingQuestion removes the pending question from the run.
 
 func (r *Run) Complete(result json.RawMessage)
-    Complete marks the run as successfully completed.
+    Complete marks the run as successfully completed, stamping the wall clock.
+    The engine uses CompleteAt with an injected clock for determinism.
+
+func (r *Run) CompleteAt(result json.RawMessage, t time.Time)
+    CompleteAt marks the run as successfully completed at the given instant.
+
+func (r *Run) ConsumedToolCalls() int
+    ConsumedToolCalls reports how many successful tool calls the run has
+    recorded. Each successful act-state tool call appends one tool-result
+    evidence record, so this is the persisted count of tool_calls budget
+    consumed — the source for seeding a resumed run's budget so a human-input
+    pause does not reset it to full.
 
 func (r *Run) Duration() time.Duration
     Duration returns the duration of the run.
 
 func (r *Run) Fail(err string)
-    Fail marks the run as failed with an error.
+    Fail marks the run as failed with an error, stamping the end time from the
+    wall clock. The engine uses FailAt with its injected clock so failure-path
+    timestamps are deterministic; Fail remains for standalone domain use.
+
+func (r *Run) FailAt(err string, t time.Time)
+    FailAt marks the run as failed with an error, stamping the end time from
+    the supplied instant. The engine passes its injected clock's time so the
+    run.failed duration payload is deterministic under a fixed clock.
 
 func (r *Run) GetVar(key string) (any, bool)
     GetVar retrieves a variable from the run context.
@@ -224,10 +290,25 @@ func (r *Run) SetVar(key string, value any)
     SetVar sets a variable in the run context.
 
 func (r *Run) Start()
-    Start marks the run as running.
+    Start marks the run as running, stamping the start time from the wall clock.
+    The engine drives runs via StartAt with an injected clock so replayed and
+    forked runs reproduce identical timestamps; Start remains for standalone
+    domain use.
+
+func (r *Run) StartAt(t time.Time)
+    StartAt marks the run as running, stamping the start time from the supplied
+    instant. The engine passes its injected clock's time so the run start
+    timestamp is deterministic under a fixed clock — no transient wall-clock
+    value is ever stamped before the engine overrides it.
 
 func (r *Run) TransitionTo(state State)
-    TransitionTo changes the current state.
+    TransitionTo changes the current state, stamping terminal end time from the
+    wall clock. The engine drives transitions via the state machine interpreter;
+    TransitionToAt is available for standalone domain use with an injected
+    clock.
+
+func (r *Run) TransitionToAt(state State, t time.Time)
+    TransitionToAt changes the current state, stamping terminal end time from t.
 
 type RunStatus string
     RunStatus represents the current status of a run.
@@ -299,8 +380,9 @@ func (r *StateRegistry) AllStatesIncludingCustom() []State
     AllStatesIncludingCustom returns canonical states plus all custom states.
 
 func (r *StateRegistry) AllowsSideEffects(s State) bool
-    AllowsSideEffects returns true only for the canonical act state.
-    Custom states cannot opt into side effects.
+    AllowsSideEffects returns true only for the canonical act state. Custom
+    states cannot opt into side effects (Register rejects that flag); this
+    method remains fail-closed even if a registry were constructed incorrectly.
 
 func (r *StateRegistry) Get(s State) (CustomState, bool)
     Get returns the custom state definition, or an empty CustomState and false
@@ -316,8 +398,9 @@ func (r *StateRegistry) IsValid(s State) bool
 
 func (r *StateRegistry) Register(cs CustomState) error
     Register adds a custom state to the registry. Returns an error if the state
-    name conflicts with a canonical state, is already registered, or sets
-    AllowsSideEffects (only act may permit side effects).
+    name conflicts with a canonical state or a previously registered custom
+    state, or if AllowsSideEffects is true (only the canonical act state may
+    permit side effects).
 
 type TransitionDecision struct {
 	ToState State  `json:"to_state"`

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -20,7 +20,6 @@ Create a minimal agent with a tool and scripted planner:
 
 
 
-
 The agent operates within a canonical state graph:
 
 ## Full API Reference
@@ -55,18 +54,13 @@ Create a minimal agent with a tool and scripted planner:
         api.ScriptStep{ExpectState: api.StateDecide, Decision: api.NewFinishDecision("completed", result)},
     )
 
-    // 3. Configure tool eligibility
-    // Option A: Declarative style (recommended for static configuration)
+    // 3. Configure tool eligibility (optional)
+    // When omitted, the engine uses NewDefaultToolEligibility(): wildcard allow
+    // in explore/decide/act/validate. Prefer an explicit allow-list in production.
     eligibility := api.NewToolEligibilityWith(api.EligibilityRules{
         api.StateExplore: {"echo", "read_file"},
         api.StateAct:     {"write_file"},
     })
-
-    // Option B: Imperative style (useful for dynamic configuration)
-    eligibility := api.NewToolEligibility()
-    eligibility.Allow(api.StateExplore, "echo")
-    eligibility.Allow(api.StateExplore, "read_file")
-    eligibility.Allow(api.StateAct, "write_file")
 
     // 4. Create and run the engine
     engine, _ := api.New(
@@ -169,6 +163,14 @@ const (
 	StatusFailed    = agent.RunStatusFailed
 )
 const (
+	TrustNone     = protocol.TrustNone
+	TrustReadOnly = protocol.TrustReadOnly
+	TrustLimited  = protocol.TrustLimited
+	TrustFull     = protocol.TrustFull
+)
+    Re-export trust levels.
+
+const (
 	// ConfigFormatYAML is the YAML format.
 	ConfigFormatYAML = infraconfig.FormatYAML
 	// ConfigFormatJSON is the JSON format.
@@ -270,8 +272,38 @@ var (
 	// ErrInvalidHumanInput is returned when the provided input doesn't
 	// match the allowed options for the pending question.
 	ErrInvalidHumanInput = agent.ErrInvalidHumanInput
+
+	// ErrNoProgress is returned when loop detection aborts a run: too many
+	// consecutive steps made no progress (no state change and no new evidence).
+	// Tune the threshold with WithMaxNoProgress.
+	ErrNoProgress = agent.ErrNoProgress
+
+	// ErrMaxSteps is returned when a run reaches MaxSteps without entering a
+	// terminal state.
+	ErrMaxSteps = agent.ErrMaxSteps
+
+	// ErrAuditFailed is returned when strict audit is enabled and a configured
+	// EventStore or RunStore fails to persist an audit record.
+	ErrAuditFailed = agent.ErrAuditFailed
+
+	// ErrTransitionRejected indicates a requested transition was rejected by
+	// policy or the state machine. The engine feeds this back to the planner
+	// rather than hard-failing on the first rejection.
+	ErrTransitionRejected = agent.ErrTransitionRejected
+
+	// ErrToolNotAllowed is returned when a tool is not eligible in the current state.
+	ErrToolNotAllowed = tool.ErrToolNotAllowed
 )
     Re-export human input related errors.
+
+var (
+	NewMessage     = protocol.NewRequest
+	NewNotify      = protocol.NewNotify
+	NewBroadcast   = protocol.NewBroadcast
+	NewTrustPolicy = protocol.NewTrustPolicy
+	NewTaskContext = task.NewContext
+)
+    Re-export protocol constructors.
 
 var (
 	// ErrKnowledgeNotFound indicates the requested vector was not found.
@@ -326,6 +358,38 @@ var (
 )
     Notification errors.
 
+var ErrInvalidStep = application.ErrInvalidStep
+    ErrInvalidStep indicates a fork/reconstruct was requested at a step index
+    below 1 (steps are 1-based).
+
+var NewAxiFactory = governance.NewAxiFactory
+    NewAxiFactory returns a factory that delegates only destructive-tool
+    approval to axi while keeping run-level budget in agent-go (the default).
+
+var NewFixedClock = clock.Fixed
+    NewFixedClock returns a deterministic clock that always reports t.
+
+var NewKernelFactory = governance.NewKernelFactory
+    NewKernelFactory returns a factory that fully delegates budget, approval,
+    and evidence to one axi session per run.
+
+var NewLogger = logging.NewLogger
+    NewLogger wraps a bolt.Logger for injection via WithLogger.
+
+var NewLoggerFromConfig = logging.NewLoggerFromConfig
+    NewLoggerFromConfig builds a configured logger without touching the
+    package-level logging singleton.
+
+var NewNopLogger = logging.NewNopLogger
+    NewNopLogger returns a logger that discards all output.
+
+var NewPassthroughFactory = governance.NewPassthroughFactory
+    NewPassthroughFactory returns a factory that keeps budget and approval
+    in-process (approval via engine middleware).
+
+var SystemClock = clock.System
+    SystemClock returns the default time.Now-backed clock.
+
 
 FUNCTIONS
 
@@ -363,6 +427,9 @@ func ExpandEnvStrict(input string) (string, error)
     ExpandEnvStrict expands environment variables and returns an error for
     missing vars.
 
+func NewArtifactStore(basePath string) (artifact.Store, error)
+    NewArtifactStore creates a filesystem artifact store under basePath.
+
 func NewAutoApprover(name string) *policy.AutoApprover
     NewAutoApprover creates an approver that automatically approves all
     requests.
@@ -395,12 +462,11 @@ func NewDenyApprover(reason string) *policy.DenyApprover
 func NewEligibilityGenerator() suggestion.Generator
     NewEligibilityGenerator creates a generator for eligibility suggestions.
 
+func NewEventStore() event.Store
+    NewEventStore creates an in-memory event store for Stream/Replay/Fork.
+
 func NewFailureDetector(eventStore EventStore, runStore RunStore) pattern.Detector
     NewFailureDetector creates a detector for failure patterns.
-
-func NewHybridPlanner(rules *planner.RuleBasedPlanner, fallback planner.Planner) *planner.HybridPlanner
-    NewHybridPlanner creates a hybrid planner that tries rules first, then falls
-    back to the given planner when no rule matches.
 
 func NewInspector(
 	runExporter inspector.RunExporter,
@@ -421,9 +487,6 @@ func NewMemoryCache(maxEntries int) *memory.Cache
 func NewMetricsExporter(runStore RunStore, eventStore EventStore) inspector.MetricsExporter
     NewMetricsExporter creates a new metrics exporter.
 
-func NewMockPlanner(decisions ...Decision) *planner.MockPlanner
-    NewMockPlanner creates a mock planner with predefined decisions.
-
 func NewPatternStore() pattern.Store
     NewPatternStore creates a new in-memory pattern store.
 
@@ -439,18 +502,22 @@ func NewPolicyVersionStore() policy.VersionStore
 func NewProposalStore() proposal.Store
     NewProposalStore creates a new in-memory proposal store.
 
-func NewRule(name string) *planner.RuleBuilder
-    NewRule creates a new rule builder with the given name.
+func NewReplay(eventStore event.Store) *application.Replay
+    NewReplay creates a replay engine for reconstructing historical runs.
+    Requires an EventStore for loading events.
 
-func NewRuleBasedPlanner(fallback Decision, rules ...planner.Rule) *planner.RuleBasedPlanner
-    NewRuleBasedPlanner creates a rule-based planner that evaluates rules in
-    priority order. The fallback decision is returned when no rule matches.
+    Example:
+
+        replay := api.NewReplay(eventStore)
+        run, _ := replay.ReconstructRun(ctx, "run-123")
+        timeline, _ := replay.NewTimeline(ctx, "run-123")
+        fmt.Println("Duration:", timeline.Duration())
 
 func NewRunExporter(runStore RunStore, eventStore EventStore) inspector.RunExporter
     NewRunExporter creates a new run exporter.
 
-func NewScriptedPlanner(steps ...planner.ScriptStep) *planner.ScriptedPlanner
-    NewScriptedPlanner creates a scripted planner for deterministic testing.
+func NewRunStore() run.Store
+    NewRunStore creates an in-memory run store for persisting run snapshots.
 
 func NewSequenceDetector(eventStore EventStore, runStore RunStore) pattern.Detector
     NewSequenceDetector creates a detector for tool sequence patterns.
@@ -550,6 +617,9 @@ type AgentConfig = domainconfig.AgentConfig
 func DefaultAgentConfig() *AgentConfig
     DefaultAgentConfig returns a minimal default configuration.
 
+type AgentDescriptor = protocol.AgentDescriptor
+    AgentDescriptor describes an agent's capabilities and trust level.
+
 type AgentSettings = domainconfig.AgentSettings
     AgentSettings contains core agent behavior settings.
 
@@ -619,6 +689,9 @@ func NewCallbackApprover(fn func(ctx context.Context, req ApprovalRequest) (bool
 func (c *CallbackApprover) Approve(ctx context.Context, req ApprovalRequest) (ApprovalResponse, error)
     Approve processes the approval request using the callback function.
 
+type Capability = protocol.Capability
+    Capability advertises what an agent can do.
+
 type ChangeType = proposal.ChangeType
     ChangeType categorizes the type of policy change.
 
@@ -631,6 +704,9 @@ type CircuitBreakerMetricsRecorder = inframw.CircuitBreakerMetricsRecorder
 func NewCircuitBreakerMetricsRecorder(provider Metrics) CircuitBreakerMetricsRecorder
     NewCircuitBreakerMetricsRecorder creates a recorder for circuit breaker
     metrics.
+
+type Clock = clock.Clock
+    Clock abstracts the source of wall-clock time for the runtime.
 
 type ConfigBuildResult = infraconfig.BuildResult
     ConfigBuildResult contains the built components from configuration.
@@ -669,6 +745,10 @@ func ConfigWithValidation(enabled bool) ConfigLoaderOption
 type Decision = agent.Decision
     Decision represents the planner's output.
 
+func NewAskHumanDecision(question string, options ...string) Decision
+    NewAskHumanDecision creates a decision to pause and ask for human input.
+    Resume with Engine.ResumeWithInput after the operator answers.
+
 func NewCallToolDecision(toolName string, input []byte, reason string) Decision
     NewCallToolDecision creates a decision to execute a tool.
 
@@ -680,6 +760,22 @@ func NewFinishDecision(summary string, result []byte) Decision
 
 func NewTransitionDecision(toState State, reason string) Decision
     NewTransitionDecision creates a decision to transition states.
+
+type DelegateOption = infraagent.DelegateOption
+    DelegateOption configures a DelegateTool.
+
+func WithDelegateRiskLevel(level RiskLevel) DelegateOption
+    WithDelegateRiskLevel sets the risk annotation on the delegate tool.
+
+func WithDelegateTaskContext(tc *TaskContext) DelegateOption
+    WithDelegateTaskContext shares a TaskContext across parent/child runs.
+
+type DelegateTool = infraagent.DelegateTool
+    DelegateTool wraps a child Engine as a tool.
+
+func NewDelegateTool(name, description string, child *Engine, opts ...DelegateOption) *DelegateTool
+    NewDelegateTool wraps child as a tool named name for agent composition.
+    Callers pass *api.Engine; no need to import infrastructure/agent.
 
 type DetectionOptions = pattern.DetectionOptions
     DetectionOptions configures pattern detection.
@@ -709,6 +805,38 @@ type Engine struct {
 
 func New(opts ...Option) (*Engine, error)
     New creates a new Engine with the provided options.
+
+func (e *Engine) ContinueRun(ctx context.Context, run *Run) (*Run, error)
+    ContinueRun drives a reconstructed run (e.g. the result of Fork or a replay)
+    further from its current state. It re-attaches a fresh state machine and
+    per-run governor and resumes the step loop, re-applying the full pipeline:
+    the structural act-gate (side effects only in act), governance authorization
+    (budget + approval), and the event stream. The run's tool-call budget is
+    seeded with the calls already consumed so a continued run does not reset its
+    run-spanning budget. A nil or already-terminal run returns an error.
+
+    Example:
+
+        forked, _ := engine.Fork(ctx, "run-123", 3)
+        final, _ := engine.ContinueRun(ctx, forked)
+
+func (e *Engine) Fork(ctx context.Context, runID string, stepN int) (*Run, error)
+    Fork branches a new run from an existing run's event history at the given
+    step. The source run is reconstructed up to and including its first stepN
+    executed steps (decision boundaries), and that state — goal, variables,
+    evidence, current state — is materialized into a fresh run with a new ID and
+    a lineage link back to the parent. The fork is persisted (when a run store
+    is configured) and a lineage event is written to its event stream.
+
+    Requires an event store (WithEventStore). Pair with WithClock for fully
+    deterministic forks. stepN must be >= 1. The returned run is in its
+    reconstructed state and not yet re-executed — inspect it, or drive it
+    further with ContinueRun.
+
+    Example:
+
+        forked, _ := engine.Fork(ctx, "run-123", 3) // branch after 3 steps
+        forked, _ = engine.ContinueRun(ctx, forked) // resume the branch
 
 func (e *Engine) Knowledge() knowledge.Store
     Knowledge returns the knowledge store, if configured. Returns nil if no
@@ -765,6 +893,9 @@ func FilterByType(types ...EventType) EventFilter
     FilterByType creates a filter that only allows events of the specified
     types.
 
+type EventIterator = application.EventIterator
+    EventIterator steps through events sequentially.
+
 type EventStore = event.Store
     EventStore stores events for pattern detection.
 
@@ -777,11 +908,47 @@ type Evidence = agent.Evidence
 type ExecutionContext = middleware.ExecutionContext
     ExecutionContext contains all information needed for middleware decisions.
 
+type Executor = resilience.Executor
+    Executor is the resilient tool executor. Prefer api.NewDefaultExecutor over
+    importing infrastructure/resilience.
+
+func NewDefaultExecutor() *Executor
+    NewDefaultExecutor returns a resilient executor with default settings.
+
+func NewExecutorWithOptions(opts ...ExecutorOption) *Executor
+    NewExecutorWithOptions returns a resilient executor with the given options.
+
+type ExecutorOption = resilience.Option
+    ExecutorOption configures a resilient executor.
+
+func WithExecutorMaxConcurrent(n int) ExecutorOption
+    WithExecutorMaxConcurrent sets the bulkhead concurrency limit.
+
+func WithExecutorRetryAttempts(n int) ExecutorOption
+    WithExecutorRetryAttempts sets max retries for idempotent tools.
+
+func WithExecutorRetryDelay(d time.Duration) ExecutorOption
+    WithExecutorRetryDelay sets the initial retry backoff delay.
+
+func WithExecutorTimeout(d time.Duration) ExecutorOption
+    WithExecutorTimeout sets the default tool execution timeout.
+
 type ExportFormat = inspector.ExportFormat
     ExportFormat specifies the output format for exports.
 
+type GovernanceFactory = governance.Factory
+    GovernanceFactory constructs per-run governors. Prefer the api constructors
+    below over importing infrastructure/governance.
+
 type Handler = middleware.Handler
     Handler executes a tool and returns its result.
+
+type HybridPlanner = planner.HybridPlanner
+    HybridPlanner tries rules first, then a fallback planner.
+
+func NewHybridPlanner(rules *RuleBasedPlanner, fallback domainplanner.Planner) *HybridPlanner
+    NewHybridPlanner creates a hybrid planner that tries rules first, then falls
+    back to the given planner when no rule matches.
 
 type ImpactLevel = suggestion.ImpactLevel
     ImpactLevel indicates the potential impact of a suggestion.
@@ -818,13 +985,26 @@ func NewLegacyMiddlewareCache(maxEntries int) *LegacyMiddlewareCache
 type ListFilter = knowledge.ListFilter
     ListFilter provides filtering options for knowledge list operations.
 
+type Logger = logging.Logger
+    Logger is the injectable structured logger used by the engine.
+
+type LoggerConfig = logging.Config
+    LoggerConfig configures a logger built via NewLoggerFromConfig.
+
 type LoggingMiddlewareConfig struct {
 	// LogInput logs the tool input (may contain sensitive data).
 	LogInput bool
 	// LogOutput logs the tool output (may be large).
 	LogOutput bool
+	// Logger is the injected structured logger. When nil, the middleware uses
+	// a no-op logger and emits nothing — it never falls back to the
+	// package-level logging singleton. Build one with NewLogger.
+	Logger *logging.Logger
 }
     LoggingMiddlewareConfig configures the logging middleware.
+
+type Message = protocol.Message
+    Message is the envelope for inter-agent communication.
 
 type Metrics = metrics.Metrics
     Metrics is the interface for recording metrics.
@@ -891,6 +1071,12 @@ type MiddlewareRegistry = middleware.Registry
 func NewMiddlewareRegistry() *MiddlewareRegistry
     NewMiddlewareRegistry creates a new middleware registry.
 
+type MockPlanner = planner.MockPlanner
+    MockPlanner is a test planner with a fixed decision sequence.
+
+func NewMockPlanner(decisions ...Decision) *MockPlanner
+    NewMockPlanner creates a mock planner with predefined decisions.
+
 type NoopMetricsProvider = metrics.NoopProvider
     NoopMetricsProvider is a no-op implementation for testing.
 
@@ -916,17 +1102,79 @@ func WithBudget(name string, limit int) Option
 func WithBudgets(budgets map[string]int) Option
     WithBudgets sets budget limits.
 
+func WithClock(c clock.Clock) Option
+    WithClock injects the clock used for run IDs, run start timestamps,
+    and event timestamps. When unset, the system clock is used. Inject a fixed
+    clock or a statekit FakeClock for deterministic replay, fork, and tests.
+
+    Example (deterministic events):
+
+        clk := api.NewFixedClock(time.Unix(0, 0).UTC())
+        engine, _ := api.New(api.WithPlanner(p), api.WithEventStore(store), api.WithClock(clk))
+
 func WithEventStore(s event.Store) Option
     WithEventStore sets the event store for event sourcing and streaming.
-    Required for the Stream() method to work.
+    Required for Stream(), Replay, and Fork. When configured, strict audit is
+    enabled by default (Append failures fail the run).
 
-func WithExecutor(e *resilience.Executor) Option
+    Audit clarity: the engine's per-run ledger is ephemeral. EventStore is the
+    durable audit trail — configure it in production if you need queryable
+    history.
+
+func WithExecutor(e *Executor) Option
     WithExecutor sets the resilient executor.
+
+func WithGovernance(f GovernanceFactory) Option
+    WithGovernance selects the governance backend that enforces act-state tool
+    budget, approval, and the evidence trail. When unset, the engine delegates
+    the destructive-tool approval gate to an axi.Kernel (AxiFactory) while the
+    run-level budget stays in agent-go.
+
+    Use api.NewKernelFactory(approver) for full delegation — each run executes
+    as one axi session so budget, approval, and evidence are all axi-native.
+    Use api.NewPassthroughFactory(approver) to keep budget and approval fully
+    in-process (approval via the engine middleware).
+
+func WithInputValidation(maxInputBytes int) Option
+    WithInputValidation enables an invocation-time input-validation guard that
+    validates each tool input against its JSON schema and, when maxInputBytes
+    > 0, rejects inputs larger than that many bytes. This bounds untrusted or
+    LLM-produced payloads before they reach tool handlers.
+
+    This is structural/schema validation, not prompt-injection content
+    detection: the framework's primary defense against malicious tool use is the
+    structural act-gate, tool eligibility, and governance/approval. For callable
+    field-level validators (email, url, uuid, etc.) use contrib/pack-validate.
+
+    Note: the engine's default middleware chain already performs schema input
+    validation; use this option to add a size bound or when supplying a custom
+    middleware chain.
+
+    Example:
+
+        engine, _ := api.New(
+            api.WithPlanner(planner),
+            api.WithInputValidation(64*1024), // reject tool inputs over 64 KiB
+        )
 
 func WithKnowledgeStore(s knowledge.Store) Option
     WithKnowledgeStore sets the knowledge store for RAG (Retrieval-Augmented
     Generation). The knowledge store enables agents to store and retrieve
     knowledge based on semantic similarity using vector embeddings.
+
+func WithLogger(l *Logger) Option
+    WithLogger injects a structured logger into the engine. When unset,
+    the engine emits no logs and never depends on a global logging singleton.
+
+    Example:
+
+        logger := api.NewLoggerFromConfig(api.LoggerConfig{Level: "info", Format: "json"})
+        engine, _ := api.New(api.WithPlanner(p), api.WithLogger(logger))
+
+func WithMaxNoProgress(n int) Option
+    WithMaxNoProgress sets loop detection: a run is aborted after this many
+    consecutive steps that make no progress (no state change and no new
+    evidence). Zero uses the default (6).
 
 func WithMaxSteps(n int) Option
     WithMaxSteps sets the maximum number of execution steps.
@@ -950,11 +1198,10 @@ func WithMetrics(provider Metrics) Option
         )
 
 func WithMiddleware(middlewares ...middleware.Middleware) Option
-    WithMiddleware sets a custom middleware registry for tool execution.
-    If not set, the engine uses a default middleware chain with: - Eligibility
-    middleware (tool access control per state) - Approval middleware (human
-    approval for destructive tools) - Logging middleware (execution timing and
-    results)
+    WithMiddleware appends middleware to the engine's default policy chain.
+    The default chain always includes validation, eligibility, approval (when
+    governance does not own it), and logging — caller middleware cannot replace
+    those policy gates. Use this for rate limiting, metrics, caching, etc.
 
 func WithPerToolRateLimit(defaultRate, defaultBurst int, toolRates map[string]ToolRateConfig) Option
     WithPerToolRateLimit enables per-tool rate limiting. Each tool can have its
@@ -970,7 +1217,7 @@ func WithPerToolRateLimit(defaultRate, defaultBurst int, toolRates map[string]To
             }),
         )
 
-func WithPlanner(p planner.Planner) Option
+func WithPlanner(p domainplanner.Planner) Option
     WithPlanner sets the planner.
 
 func WithRateLimit(rate, burst int) Option
@@ -994,6 +1241,17 @@ func WithRegistry(r tool.Registry) Option
 func WithRunStore(s run.Store) Option
     WithRunStore sets the run store for persistent run state. Runs are
     automatically saved on creation and updated on each step.
+
+func WithStrictAudit(strict bool) Option
+    WithStrictAudit overrides audit persistence failure handling. When true,
+    EventStore.Append and RunStore Save/Update errors fail the run. When false,
+    persistence errors are logged and the run continues. The default is true
+    whenever an EventStore is configured.
+
+func WithTaskContext(tc *task.Context) Option
+    WithTaskContext sets a shared task context for multi-agent coordination.
+    Enables shared variables, evidence, and artifact references across parent
+    and child agents in a delegation hierarchy.
 
 func WithTool(t tool.Tool) Option
     WithTool registers a tool with the engine's registry. Can be called multiple
@@ -1039,6 +1297,13 @@ func WithLongRunThreshold(d time.Duration) PerformanceDetectorOption
 func WithSlowToolThreshold(d time.Duration) PerformanceDetectorOption
     WithSlowToolThreshold sets the threshold for slow tool detection.
 
+type PlanRequest = domainplanner.PlanRequest
+    PlanRequest is the input to Planner.Plan.
+
+type Planner = domainplanner.Planner
+    Planner is the decision-engine contract (domain). Implementations may live
+    in infrastructure or external packages; callers need not import infra.
+
 type PolicyApplier = infraProposal.PolicyApplier
     PolicyApplier applies approved proposals to policy configuration.
 
@@ -1081,6 +1346,11 @@ type RateLimitMetricsRecorder = inframw.RateLimitMetricsRecorder
 func NewRateLimitMetricsRecorder(provider Metrics) RateLimitMetricsRecorder
     NewRateLimitMetricsRecorder creates a recorder for rate limit metrics.
 
+type Replay = application.Replay
+    Replay provides run reconstruction and timeline analysis from events.
+    It also supports step-bounded reconstruction via ReconstructRunAtStep,
+    the primitive behind Engine.Fork.
+
 type ResilienceConfig = domainconfig.ResilienceConfig
     ResilienceConfig contains resilience settings.
 
@@ -1090,11 +1360,24 @@ type RetryConfigSpec = domainconfig.RetryConfig
 type RiskLevel = tool.RiskLevel
     RiskLevel indicates the potential impact of a tool execution.
 
+type Router = protocol.Router
+    Router dispatches messages between agents.
+
 type Rule = planner.Rule
     Rule is a condition-decision pair for the rule-based planner.
 
+type RuleBasedPlanner = planner.RuleBasedPlanner
+    RuleBasedPlanner evaluates Go-native rules in priority order.
+
+func NewRuleBasedPlanner(fallback Decision, rules ...planner.Rule) *RuleBasedPlanner
+    NewRuleBasedPlanner creates a rule-based planner that evaluates rules in
+    priority order. The fallback decision is returned when no rule matches.
+
 type RuleBuilder = planner.RuleBuilder
     RuleBuilder constructs rules using a fluent API.
+
+func NewRule(name string) *RuleBuilder
+    NewRule creates a new rule builder with the given name.
 
 type Run = agent.Run
     Run represents a single execution of the agent.
@@ -1125,6 +1408,12 @@ type RunStore = run.Store
 
 type ScriptStep = planner.ScriptStep
     ScriptStep is a step in a scripted planner.
+
+type ScriptedPlanner = planner.ScriptedPlanner
+    ScriptedPlanner replays a predetermined script of decisions.
+
+func NewScriptedPlanner(steps ...planner.ScriptStep) *ScriptedPlanner
+    NewScriptedPlanner creates a scripted planner for deterministic testing.
 
 type SearchResult = knowledge.SearchResult
     SearchResult represents a similarity search result.
@@ -1181,6 +1470,12 @@ type SuggestionStore = suggestion.Store
 type SuggestionType = suggestion.SuggestionType
     SuggestionType categorizes suggestions.
 
+type TaskContext = task.Context
+    TaskContext spans a multi-agent task for shared state.
+
+type Timeline = application.Timeline
+    Timeline provides temporal analysis of a run's event history.
+
 type TimelineEntry = inspector.TimelineEntry
     TimelineEntry represents an entry in the run timeline.
 
@@ -1195,6 +1490,9 @@ type ToolCallExport = inspector.ToolCallExport
 
 type ToolCompletedPayload = domainnotif.ToolCompletedPayload
     Re-export domain notification types.
+
+type ToolDef = domainplanner.ToolDef
+    ToolDef describes a tool for planning.
 
 type ToolFailedPayload = domainnotif.ToolFailedPayload
     Re-export domain notification types.
@@ -1242,6 +1540,9 @@ type TransitionRules = policy.TransitionRules
             api.StateExplore:  {api.StateDecide, api.StateFailed},
             api.StateDecide:   {api.StateAct, api.StateDone, api.StateFailed},
         })
+
+type TrustPolicy = protocol.TrustPolicy
+    TrustPolicy defines trust relationships between agents.
 
 type ValidationError = domainconfig.ValidationError
     ValidationError represents a configuration validation error.

--- a/docs/api/application.md
+++ b/docs/api/application.md
@@ -27,6 +27,13 @@ Package application provides application services.
 
 Package application provides application services.
 
+VARIABLES
+
+var ErrInvalidStep = errors.New("invalid step index")
+    ErrInvalidStep indicates a fork/reconstruct was requested at a step index
+    below 1 (steps are 1-based).
+
+
 TYPES
 
 type DetectionService struct {
@@ -63,6 +70,40 @@ func NewEngine(config EngineConfig) (*Engine, error)
 func NewEngineWithOptions(opts ...Option) (*Engine, error)
     NewEngineWithOptions creates an engine with functional options.
 
+func (e *Engine) ContinueRun(ctx context.Context, run *agent.Run) (*agent.Run, error)
+    ContinueRun drives a reconstructed run (e.g. the product of Fork or a
+    replay) further from its current state. It re-attaches a fresh state
+    machine and a new per-run Governor to the run and resumes the step loop from
+    run.CurrentState, re-applying the full pipeline: the structural act-gate,
+    governance authorization (budget + approval), and the 12-event stream.
+
+    The run's tool-call budget is seeded with the calls already consumed (the
+    persisted tool-result evidence count) so a continued fork does not silently
+    reset its run-spanning budget to full. A nil or already-terminal run is
+    returned unchanged with an error.
+
+    ContinueRun is the run-advancing counterpart to Fork: Fork reconstructs and
+    inspects, ContinueRun re-drives. Pair them to branch a run and explore the
+    branch under the same governance and act-gate guarantees as the original.
+
+func (e *Engine) Fork(ctx context.Context, runID string, stepN int) (*agent.Run, error)
+    Fork creates a new run branched from an existing run's event history at a
+    given step. The source run is reconstructed up to and including its first
+    stepN executed steps (decision.made boundaries), and the resulting state —
+    goal, variables, evidence, and current state — is materialized into a fresh
+    run with a new ID. The fork is persisted (when a run store is configured)
+    and a lineage event linking parent and child is recorded in the new run's
+    event stream.
+
+    Fork enables "what-if" branching and deterministic re-exploration from any
+    point in a run's history (pair with WithClock for fully reproducible forks).
+    The returned run is in its reconstructed state and not yet re-executed;
+    callers may inspect it, or drive it further with ContinueRun, which resumes
+    the step loop from the fork's current state under the same governance and
+    structural act-gate guarantees.
+
+    Requires an event store (use WithEventStore). stepN must be >= 1.
+
 func (e *Engine) Knowledge() knowledge.Store
     Knowledge returns the knowledge store, if configured.
 
@@ -71,6 +112,11 @@ func (e *Engine) ResumeWithInput(ctx context.Context, run *agent.Run, input stri
 
 func (e *Engine) Run(ctx context.Context, goal string) (*agent.Run, error)
     Run executes the agent with the given goal.
+
+func (e *Engine) RunInTask(ctx context.Context, goal string, tc *task.Context) (*agent.Run, error)
+    RunInTask executes the agent within a shared task context. The task context
+    enables sharing variables, evidence, and artifact references between parent
+    and child agents in a delegation hierarchy.
 
 func (e *Engine) RunWithVars(ctx context.Context, goal string, vars map[string]any) (*agent.Run, error)
     RunWithVars executes the agent with the given goal and initial variables.
@@ -83,7 +129,7 @@ func (e *Engine) Stream(ctx context.Context, goal string) (string, <-chan event.
 
 type EngineConfig struct {
 	Registry     tool.Registry
-	Planner      planner.Planner
+	Planner      domainplanner.Planner
 	Executor     *resilience.Executor
 	Artifacts    artifact.Store
 	Knowledge    knowledge.Store
@@ -92,11 +138,40 @@ type EngineConfig struct {
 	Approver     policy.Approver
 	BudgetLimits map[string]int
 	MaxSteps     int
-	Middleware   *middleware.Registry
-	Tracer       telemetry.Tracer
-	Meter        telemetry.Meter
-	RunStore     run.Store
-	EventStore   event.Store
+	// MaxNoProgress aborts a run after this many consecutive steps that make no
+	// progress — no state change AND no new evidence (e.g. the planner keeps
+	// emitting self-transitions or repeats). This is loop detection: it catches a
+	// stuck agent cheaply, long before MaxSteps. Zero uses the default (6).
+	MaxNoProgress int
+	Middleware    *middleware.Registry
+	Tracer        telemetry.Tracer
+	Meter         telemetry.Meter
+	RunStore      run.Store
+	EventStore    event.Store
+	TaskContext   *task.Context
+	// Governance selects the governance backend (budget + approval +
+	// evidence). When nil, the full-delegation KernelFactory is used: each run
+	// is ONE axi session, so budget, the destructive-tool approval gate, and
+	// the evidence chain are all axi-native.
+	Governance governance.Factory
+	// Logger is the injected structured logger. When nil, a no-op logger is
+	// used and the engine emits no logs — the execution path never falls back
+	// to the package-level logging singleton.
+	Logger *logging.Logger
+	// Clock supplies the time used for run IDs, run start timestamps, and
+	// event timestamps. When nil, the system clock is used. Inject a fixed or
+	// statekit FakeClock for deterministic replay and tests.
+	Clock clock.Clock
+	// StrictAudit, when non-nil, overrides the default audit policy. When nil,
+	// strict audit is enabled whenever EventStore is configured. Strict mode
+	// fails the run if EventStore.Append or RunStore Save/Update returns an
+	// error, instead of logging and continuing.
+	//
+	// Audit clarity: the per-run ledger created by the engine is ephemeral
+	// (in-memory for that run only). Durable, queryable audit requires an
+	// EventStore (and optionally a RunStore). Prefer WithEventStore in
+	// production; without it there is no durable audit trail.
+	StrictAudit *bool
 }
     EngineConfig contains configuration for the engine.
 
@@ -213,6 +288,11 @@ func WithArtifactStore(s artifact.Store) Option
 func WithBudgets(limits map[string]int) Option
     WithBudgets sets budget limits.
 
+func WithClock(c clock.Clock) Option
+    WithClock sets the clock used for run IDs, run start timestamps, and event
+    timestamps. When unset, the system clock is used. Inject a fixed or statekit
+    FakeClock for deterministic replay and tests.
+
 func WithEligibility(e *policy.ToolEligibility) Option
     WithEligibility sets the tool eligibility configuration.
 
@@ -223,6 +303,11 @@ func WithEventStore(s event.Store) Option
 
 func WithExecutor(e *resilience.Executor) Option
     WithExecutor sets the resilient executor.
+
+func WithLogger(l *logging.Logger) Option
+    WithLogger sets the injected structured logger for the engine. When unset,
+    the engine uses a no-op logger and emits nothing — the execution path never
+    depends on the package-level logging singleton.
 
 func WithMaxSteps(n int) Option
     WithMaxSteps sets the maximum number of steps.
@@ -237,7 +322,7 @@ func WithMiddleware(m *middleware.Registry) Option
     control per state) - Approval middleware (human approval for destructive
     tools) - Logging middleware (execution timing and results)
 
-func WithPlanner(p planner.Planner) Option
+func WithPlanner(p domainplanner.Planner) Option
     WithPlanner sets the planner.
 
 func WithRegistry(r tool.Registry) Option
@@ -248,6 +333,11 @@ func WithRunStore(s run.Store) Option
     runs are automatically saved on creation and updated on each step and
     terminal state. Persistence is best-effort — failures are logged but do not
     abort the run.
+
+func WithTaskContext(tc *task.Context) Option
+    WithTaskContext sets a shared task context for multi-agent coordination.
+    When configured, the engine merges shared variables, propagates evidence to
+    the task context, and sets ParentRunID/TaskID on runs.
 
 func WithTracer(t telemetry.Tracer) Option
     WithTracer sets the OpenTelemetry tracer for distributed tracing. When
@@ -273,6 +363,16 @@ func (r *Replay) NewTimeline(ctx context.Context, runID string) (*Timeline, erro
 
 func (r *Replay) ReconstructRun(ctx context.Context, runID string) (*agent.Run, error)
     ReconstructRun rebuilds a run's state from its event history.
+
+func (r *Replay) ReconstructRunAtStep(ctx context.Context, runID string, n int) (*agent.Run, error)
+    ReconstructRunAtStep rebuilds a run's state from its event history up to and
+    including the first n executed steps. A step boundary is a decision.made
+    event, so the reconstructed run reflects the effects of the first n planner
+    decisions (transitions, tool results, variables, evidence) and stops before
+    the (n+1)th decision.
+
+    n must be >= 1. If the run has fewer than n steps, the full history is
+    applied. This is the truncation primitive used by Engine.Fork.
 
 func (r *Replay) ReconstructRunFrom(ctx context.Context, runID string, fromSeq uint64) (*agent.Run, error)
     ReconstructRunFrom rebuilds a run's state from a starting sequence.

--- a/docs/api/artifact.md
+++ b/docs/api/artifact.md
@@ -15,6 +15,14 @@ package artifact // import "go.klarlabs.de/agent/domain/artifact"
 
 Package artifact provides domain models for artifact storage.
 
+CONSTANTS
+
+const MaxIDLength = 255
+    MaxIDLength bounds the length of an artifact ID. Filesystem-backed
+    stores use the ID as a single path component, and 255 bytes is the common
+    per-component limit on Linux and macOS.
+
+
 VARIABLES
 
 var (
@@ -34,6 +42,26 @@ var (
 	ErrChecksumMismatch = errors.New("checksum mismatch")
 )
     Domain errors for artifact storage.
+
+
+FUNCTIONS
+
+func IsValidID(id string) bool
+    IsValidID reports whether id is a well-formed artifact ID.
+
+    A valid ID is non-empty, at most MaxIDLength bytes long, is neither "." nor
+    "..", and consists only of ASCII letters, digits, '-', '_' and '.'.
+
+    The charset is deliberately narrow. Stores use the ID verbatim as a path
+    component (filesystem) or object key (GCS, S3), so path separators,
+    parent directory references and control bytes must never appear in one.
+    A Ref is a plain JSON value that can round-trip through tool output and
+    model-authored input, so an ID arriving at Retrieve/Delete/Exists/Metadata
+    is not necessarily an ID this process generated — validation is the store's
+    contract with its caller, not an assumption it may make.
+
+    The format accepts every ID the bundled stores emit: the filesystem store's
+    "<unix-nanos>-<random>" and the GCS store's UUIDs.
 
 
 TYPES
@@ -66,7 +94,9 @@ func NewRef(id string) Ref
     NewRef creates a new artifact reference.
 
 func (r Ref) IsValid() bool
-    IsValid returns true if the reference has a valid ID.
+    IsValid returns true if the reference carries a well-formed ID.
+
+    See IsValidID for the accepted format.
 
 func (r Ref) String() string
     String returns a string representation of the reference.

--- a/docs/api/event.md
+++ b/docs/api/event.md
@@ -47,6 +47,24 @@ var (
 
 TYPES
 
+type AgentDelegatedPayload struct {
+	ParentRunID string `json:"parent_run_id"`
+	ChildRunID  string `json:"child_run_id"`
+	AgentName   string `json:"agent_name"`
+	Goal        string `json:"goal"`
+}
+    AgentDelegatedPayload contains data for agent.delegated events.
+
+type AgentMessagePayload struct {
+	MessageID     string `json:"message_id"`
+	CorrelationID string `json:"correlation_id"`
+	Sender        string `json:"sender"`
+	Receiver      string `json:"receiver,omitempty"`
+	Action        string `json:"action"`
+	MessageType   string `json:"message_type"`
+}
+    AgentMessagePayload contains data for agent message events.
+
 type ApprovalRequestedPayload struct {
 	ToolName  string          `json:"tool_name"`
 	Input     json.RawMessage `json:"input"`
@@ -107,7 +125,13 @@ type Event struct {
     Event represents a domain event in the event store.
 
 func NewEvent(runID string, eventType Type, payload any) (Event, error)
-    NewEvent creates a new event with the given type and payload.
+    NewEvent creates a new event with the given type and payload, stamped with
+    the current wall-clock time. For deterministic timestamps (replay, fork,
+    tests) use NewEventAt with an injected clock's time.
+
+func NewEventAt(runID string, eventType Type, payload any, ts time.Time) (Event, error)
+    NewEventAt creates a new event stamped with the provided timestamp. The
+    engine passes its injected clock's time so an event stream is reproducible.
 
 func (e *Event) UnmarshalPayload(v any) error
     UnmarshalPayload decodes the event payload into the given value.
@@ -118,6 +142,17 @@ type EvidenceAddedPayload struct {
 	Content json.RawMessage `json:"content"`
 }
     EvidenceAddedPayload contains data for evidence.added events.
+
+type PlannerProposedPayload struct {
+	DecisionType string          `json:"decision_type"`
+	ToolName     string          `json:"tool_name,omitempty"`
+	ToState      agent.State     `json:"to_state,omitempty"`
+	Reason       string          `json:"reason,omitempty"`
+	Input        json.RawMessage `json:"input,omitempty"`
+}
+    PlannerProposedPayload contains data for planner.proposed events. This
+    captures what the planner intended BEFORE execution, allowing comparison
+    with the actual outcome (decision.made).
 
 type Pruner interface {
 	// PruneEvents removes events before a sequence number.
@@ -196,6 +231,16 @@ type Snapshotter interface {
     Snapshotter is an optional interface for stores that support snapshotting.
     Snapshots allow efficient replay by storing aggregate state at checkpoints.
 
+type StateTransitionRejectedPayload struct {
+	FromState agent.State   `json:"from_state"`
+	Attempted agent.State   `json:"attempted"`
+	Reason    string        `json:"reason,omitempty"`
+	Allowed   []agent.State `json:"allowed,omitempty"`
+}
+    StateTransitionRejectedPayload contains data for state.transition.rejected
+    events. Emitted when a Transition/Finish/Fail decision targets a disallowed
+    state; the run stays in FromState and the planner receives Feedback.
+
 type StateTransitionedPayload struct {
 	FromState agent.State `json:"from_state"`
 	ToState   agent.State `json:"to_state"`
@@ -263,7 +308,8 @@ const (
 	TypeRunResumed   Type = "run.resumed"
 
 	// State machine events
-	TypeStateTransitioned Type = "state.transitioned"
+	TypeStateTransitioned       Type = "state.transitioned"
+	TypeStateTransitionRejected Type = "state.transition.rejected"
 
 	// Tool execution events
 	TypeToolCalled    Type = "tool.called"
@@ -287,6 +333,14 @@ const (
 
 	// Variable events
 	TypeVariableSet Type = "variable.set"
+
+	// Planner events
+	TypePlannerProposed Type = "planner.proposed"
+
+	// Agent protocol events
+	TypeAgentMessageSent     Type = "agent.message.sent"
+	TypeAgentMessageReceived Type = "agent.message.received"
+	TypeAgentDelegated       Type = "agent.delegated"
 )
     Event types for the agent runtime.
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,6 +1,10 @@
 # API Documentation
 
-Generated from source using `go doc`.
+Generated from source using `go doc` (`make docs-api`).
+
+**Source of truth:** package godoc in the Go tree (`interfaces/api`, `domain/*`,
+`application`). Re-run `make docs-api` after public API changes; do not hand-edit
+these snapshots for API accuracy.
 
 ## Packages
 
@@ -18,4 +22,4 @@ Generated from source using `go doc`.
 
 ---
 
-*Generated on 2026-03-28*
+*Generated on 2026-08-15*

--- a/docs/api/policy.md
+++ b/docs/api/policy.md
@@ -35,7 +35,9 @@ var (
 	// ErrConstraintViolation indicates a policy constraint was violated.
 	ErrConstraintViolation = errors.New("constraint violation")
 
-	// ErrTransitionNotAllowed indicates the state transition is not permitted.
+	// ErrTransitionNotAllowed is deprecated: the engine uses
+	// agent.ErrTransitionRejected for soft-rejected transitions.
+	// Kept so older call sites compiling against policy still link.
 	ErrTransitionNotAllowed = errors.New("state transition not allowed")
 
 	// ErrToolNotEligible indicates the tool is not eligible in the current state.

--- a/docs/api/tool.md
+++ b/docs/api/tool.md
@@ -33,6 +33,13 @@ var (
 	// ErrToolNotAllowed indicates the tool is not allowed in the current state.
 	ErrToolNotAllowed = errors.New("tool not allowed in current state")
 
+	// ErrSideEffectInNonActState indicates a side-effecting tool was invoked in
+	// a state that does not permit side effects. This is a STRUCTURAL invariant
+	// — it is enforced independently of tool-eligibility configuration and
+	// cannot be relaxed or bypassed. Side effects are permitted only in states
+	// that allow them (canonically, the act state).
+	ErrSideEffectInNonActState = errors.New("side-effecting tool rejected outside a side-effecting state")
+
 	// ErrInvalidInput indicates the input failed schema validation.
 	ErrInvalidInput = errors.New("invalid tool input")
 
@@ -85,7 +92,9 @@ type Annotations struct {
     and planning.
 
 func DefaultAnnotations() Annotations
-    DefaultAnnotations returns annotations with safe defaults.
+    DefaultAnnotations returns conservative annotations: tools are treated as
+    side-effecting (HasSideEffects == true) until explicitly marked ReadOnly.
+    Prefer ReadOnlyAnnotations() for tools that only observe state.
 
 func DestructiveAnnotations() Annotations
     DestructiveAnnotations returns annotations for a destructive tool.
@@ -98,6 +107,19 @@ func (a Annotations) CanCache() bool
 
 func (a Annotations) CanRetry() bool
     CanRetry returns true if the tool can be safely retried on failure.
+
+func (a Annotations) HasSideEffects() bool
+    HasSideEffects reports whether executing the tool may mutate external state.
+
+    This is the STRUCTURAL definition of a side effect used to enforce the
+    non-negotiable invariant "side effects only in the act state". A tool has
+    side effects unless it is explicitly marked ReadOnly. Destructive tools
+    always have side effects, even if mislabelled ReadOnly (defensive).
+
+    Unlike ShouldRequireApproval (a configurable, risk-based policy hint),
+    this method is the ground truth the engine uses to reject side-effecting
+    tools in non-act states. It must remain a pure function of the annotations
+    and must not be widened by configuration.
 
 func (a Annotations) ShouldRequireApproval() bool
     ShouldRequireApproval returns true if the tool should require approval.
@@ -130,7 +152,10 @@ func (b *Builder) Idempotent() *Builder
     Idempotent marks the tool as idempotent.
 
 func (b *Builder) MustBuild() Tool
-    MustBuild constructs the tool definition or panics on error.
+    MustBuild constructs the tool definition or panics on error. This is
+    intentional — use MustBuild only for static tool definitions where a build
+    failure indicates a programming error (e.g., missing name). For dynamic tool
+    creation where errors are expected, use Build instead.
 
 func (b *Builder) ReadOnly() *Builder
     ReadOnly marks the tool as read-only.
@@ -289,8 +314,11 @@ func (s *Schema) UnmarshalJSON(data []byte) error
     UnmarshalJSON implements json.Unmarshaler.
 
 func (s Schema) Validate(data json.RawMessage) error
-    Validate validates data against the schema. For now, this is a placeholder -
-    full JSON Schema validation will be implemented in internal/schema.
+    Validate validates data against a practical JSON Schema subset:
+    top-level type, required object properties, and per-property type checks.
+    Nested schemas beyond one property level and keywords like pattern/minimum
+    are not enforced here; use a full Draft 2020-12 validator in infrastructure
+    when needed.
 
 type Tool interface {
 	// Name returns the stable string identifier for the tool.

--- a/docs/concepts/states.md
+++ b/docs/concepts/states.md
@@ -89,37 +89,33 @@ States transition based on planner decisions or engine logic:
 // Planner can request a transition
 decision := agent.NewTransitionDecision(agent.StateExplore, "need more info")
 
-// Engine validates the transition is legal
-// Invalid transitions cause errors, not undefined behavior
+// Invalid Transition/Finish/Fail targets are soft-rejected: state is unchanged,
+// PlanRequest.Feedback explains the allowed targets, and a
+// state.transition.rejected event is published. Loop detection bounds retries.
 ```
 
-### Valid Transitions
+### Valid Transitions (`DefaultTransitions`)
 
-| From | To | Condition |
-|------|----|-----------|
-| `intake` | `explore` | Always valid |
-| `intake` | `failed` | On error |
-| `explore` | `decide` | When ready to act |
-| `explore` | `done` | Enough info to finish |
-| `explore` | `failed` | On error |
-| `decide` | `act` | Ready to execute |
-| `decide` | `done` | No action needed |
-| `decide` | `explore` | Need more info |
-| `decide` | `failed` | Cannot proceed |
-| `act` | `validate` | After execution |
-| `act` | `failed` | On error |
-| `validate` | `done` | Success verified |
-| `validate` | `explore` | Need more info |
-| `validate` | `failed` | Validation failed |
+| From | To |
+|------|----|
+| `intake` | `explore`, `failed` |
+| `explore` | `decide`, `failed` |
+| `decide` | `act`, `done`, `failed` |
+| `act` | `validate`, `failed` |
+| `validate` | `done`, `explore`, `failed` |
+
+`Finish` requires a path to `done` (from `decide` or `validate`). `Fail` requires a path to `failed`.
 
 ### Custom Transitions
 
-You can configure custom transition rules:
-
 ```go
-transitions := agent.NewTransitionGraph()
-transitions.Allow(agent.StateExplore, agent.StateAct)  // Skip decide
-transitions.Deny(agent.StateAct, agent.StateExplore)   // No going back
+transitions := agent.NewStateTransitionsWith(agent.TransitionRules{
+    agent.StateIntake:   {agent.StateExplore, agent.StateFailed},
+    agent.StateExplore:  {agent.StateDecide, agent.StateAct, agent.StateFailed}, // skip decide
+    agent.StateDecide:   {agent.StateAct, agent.StateDone, agent.StateFailed},
+    agent.StateAct:      {agent.StateValidate, agent.StateFailed},
+    agent.StateValidate: {agent.StateDone, agent.StateFailed},
+})
 
 engine, _ := agent.New(
     agent.WithTransitions(transitions),
@@ -134,32 +130,14 @@ The most common use of states is controlling tool access:
 eligibility := agent.NewToolEligibility()
 
 // Read-only tools: explore and validate
-eligibility.Allow(agent.StateExplore, "read_file", "list_dir", "search")
-eligibility.Allow(agent.StateValidate, "read_file", "check_result")
+eligibility.AllowMultiple(agent.StateExplore, "read_file", "list_dir", "search")
+eligibility.AllowMultiple(agent.StateValidate, "read_file", "check_result")
 
 // Destructive tools: act only
-eligibility.Allow(agent.StateAct, "write_file", "delete_file", "execute")
+eligibility.AllowMultiple(agent.StateAct, "write_file", "delete_file", "execute")
 
 engine, _ := agent.New(
     agent.WithToolEligibility(eligibility),
-)
-```
-
-## State Guards
-
-Guards add conditions to state transitions:
-
-```go
-// Only allow transition to 'act' if we have enough evidence
-guard := func(ctx context.Context, run *agent.Run, to agent.State) bool {
-    if to == agent.StateAct {
-        return len(run.Evidence) >= 2  // Need at least 2 pieces of evidence
-    }
-    return true
-}
-
-engine, _ := agent.New(
-    agent.WithTransitionGuard(guard),
 )
 ```
 

--- a/domain/event/event_test.go
+++ b/domain/event/event_test.go
@@ -119,6 +119,7 @@ func TestEventTypes(t *testing.T) {
 		{event.TypeRunPaused, "run.paused"},
 		{event.TypeRunResumed, "run.resumed"},
 		{event.TypeStateTransitioned, "state.transitioned"},
+		{event.TypeStateTransitionRejected, "state.transition.rejected"},
 		{event.TypeToolCalled, "tool.called"},
 		{event.TypeToolSucceeded, "tool.succeeded"},
 		{event.TypeToolFailed, "tool.failed"},

--- a/domain/event/types.go
+++ b/domain/event/types.go
@@ -20,7 +20,8 @@ const (
 	TypeRunResumed   Type = "run.resumed"
 
 	// State machine events
-	TypeStateTransitioned Type = "state.transitioned"
+	TypeStateTransitioned       Type = "state.transitioned"
+	TypeStateTransitionRejected Type = "state.transition.rejected"
 
 	// Tool execution events
 	TypeToolCalled    Type = "tool.called"
@@ -80,6 +81,16 @@ type StateTransitionedPayload struct {
 	FromState agent.State `json:"from_state"`
 	ToState   agent.State `json:"to_state"`
 	Reason    string      `json:"reason"`
+}
+
+// StateTransitionRejectedPayload contains data for state.transition.rejected events.
+// Emitted when a Transition/Finish/Fail decision targets a disallowed state;
+// the run stays in FromState and the planner receives Feedback.
+type StateTransitionRejectedPayload struct {
+	FromState agent.State   `json:"from_state"`
+	Attempted agent.State   `json:"attempted"`
+	Reason    string        `json:"reason,omitempty"`
+	Allowed   []agent.State `json:"allowed,omitempty"`
 }
 
 // ToolCalledPayload contains data for tool.called events.

--- a/domain/policy/errors.go
+++ b/domain/policy/errors.go
@@ -18,7 +18,9 @@ var (
 	// ErrConstraintViolation indicates a policy constraint was violated.
 	ErrConstraintViolation = errors.New("constraint violation")
 
-	// ErrTransitionNotAllowed indicates the state transition is not permitted.
+	// ErrTransitionNotAllowed is deprecated: the engine uses
+	// agent.ErrTransitionRejected for soft-rejected transitions.
+	// Kept so older call sites compiling against policy still link.
 	ErrTransitionNotAllowed = errors.New("state transition not allowed")
 
 	// ErrToolNotEligible indicates the tool is not eligible in the current state.

--- a/interfaces/api/agent.go
+++ b/interfaces/api/agent.go
@@ -86,6 +86,7 @@ package api
 
 import (
 	"context"
+	"time"
 
 	"go.klarlabs.de/agent/application"
 	"go.klarlabs.de/agent/domain/agent"
@@ -774,9 +775,37 @@ func WithLogger(l *Logger) Option {
 // over importing infrastructure/resilience.
 type Executor = resilience.Executor
 
+// ExecutorOption configures a resilient executor.
+type ExecutorOption = resilience.Option
+
 // NewDefaultExecutor returns a resilient executor with default settings.
 func NewDefaultExecutor() *Executor {
 	return resilience.NewDefaultExecutor()
+}
+
+// NewExecutorWithOptions returns a resilient executor with the given options.
+func NewExecutorWithOptions(opts ...ExecutorOption) *Executor {
+	return resilience.NewExecutorWithOptions(opts...)
+}
+
+// WithExecutorTimeout sets the default tool execution timeout.
+func WithExecutorTimeout(d time.Duration) ExecutorOption {
+	return resilience.WithTimeout(d)
+}
+
+// WithExecutorMaxConcurrent sets the bulkhead concurrency limit.
+func WithExecutorMaxConcurrent(n int) ExecutorOption {
+	return resilience.WithMaxConcurrent(n)
+}
+
+// WithExecutorRetryAttempts sets max retries for idempotent tools.
+func WithExecutorRetryAttempts(n int) ExecutorOption {
+	return resilience.WithRetryAttempts(n)
+}
+
+// WithExecutorRetryDelay sets the initial retry backoff delay.
+func WithExecutorRetryDelay(d time.Duration) ExecutorOption {
+	return resilience.WithRetryDelay(d)
 }
 
 // GovernanceFactory constructs per-run governors. Prefer the api constructors

--- a/interfaces/api/builders.go
+++ b/interfaces/api/builders.go
@@ -29,14 +29,20 @@ func NewKnowledgeStore(dimension int) *memory.KnowledgeStore {
 }
 
 // NewMockPlanner creates a mock planner with predefined decisions.
-func NewMockPlanner(decisions ...Decision) *planner.MockPlanner {
+func NewMockPlanner(decisions ...Decision) *MockPlanner {
 	return planner.NewMockPlanner(decisions...)
 }
 
+// MockPlanner is a test planner with a fixed decision sequence.
+type MockPlanner = planner.MockPlanner
+
 // NewScriptedPlanner creates a scripted planner for deterministic testing.
-func NewScriptedPlanner(steps ...planner.ScriptStep) *planner.ScriptedPlanner {
+func NewScriptedPlanner(steps ...planner.ScriptStep) *ScriptedPlanner {
 	return planner.NewScriptedPlanner(steps...)
 }
+
+// ScriptedPlanner replays a predetermined script of decisions.
+type ScriptedPlanner = planner.ScriptedPlanner
 
 // ScriptStep is a step in a scripted planner.
 type ScriptStep = planner.ScriptStep
@@ -48,19 +54,25 @@ type Rule = planner.Rule
 type RuleBuilder = planner.RuleBuilder
 
 // NewRule creates a new rule builder with the given name.
-func NewRule(name string) *planner.RuleBuilder {
+func NewRule(name string) *RuleBuilder {
 	return planner.NewRule(name)
 }
 
+// RuleBasedPlanner evaluates Go-native rules in priority order.
+type RuleBasedPlanner = planner.RuleBasedPlanner
+
 // NewRuleBasedPlanner creates a rule-based planner that evaluates rules in priority order.
 // The fallback decision is returned when no rule matches.
-func NewRuleBasedPlanner(fallback Decision, rules ...planner.Rule) *planner.RuleBasedPlanner {
+func NewRuleBasedPlanner(fallback Decision, rules ...planner.Rule) *RuleBasedPlanner {
 	return planner.NewRuleBasedPlanner(fallback, rules...)
 }
 
+// HybridPlanner tries rules first, then a fallback planner.
+type HybridPlanner = planner.HybridPlanner
+
 // NewHybridPlanner creates a hybrid planner that tries rules first,
 // then falls back to the given planner when no rule matches.
-func NewHybridPlanner(rules *planner.RuleBasedPlanner, fallback domainplanner.Planner) *planner.HybridPlanner {
+func NewHybridPlanner(rules *RuleBasedPlanner, fallback domainplanner.Planner) *HybridPlanner {
 	return planner.NewHybridPlanner(rules, fallback)
 }
 

--- a/interfaces/api/delegate.go
+++ b/interfaces/api/delegate.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"go.klarlabs.de/agent/domain/artifact"
+	"go.klarlabs.de/agent/domain/event"
+	"go.klarlabs.de/agent/domain/run"
+	infraagent "go.klarlabs.de/agent/infrastructure/agent"
+	"go.klarlabs.de/agent/infrastructure/storage/filesystem"
+	"go.klarlabs.de/agent/infrastructure/storage/memory"
+)
+
+// In-memory stores (prefer these over importing infrastructure/storage/*).
+
+// NewEventStore creates an in-memory event store for Stream/Replay/Fork.
+func NewEventStore() event.Store {
+	return memory.NewEventStore()
+}
+
+// NewRunStore creates an in-memory run store for persisting run snapshots.
+func NewRunStore() run.Store {
+	return memory.NewRunStore()
+}
+
+// NewArtifactStore creates a filesystem artifact store under basePath.
+func NewArtifactStore(basePath string) (artifact.Store, error) {
+	return filesystem.NewArtifactStore(basePath)
+}
+
+// Multi-agent delegation
+
+// DelegateTool wraps a child Engine as a tool.
+type DelegateTool = infraagent.DelegateTool
+
+// DelegateOption configures a DelegateTool.
+type DelegateOption = infraagent.DelegateOption
+
+// WithDelegateTaskContext shares a TaskContext across parent/child runs.
+func WithDelegateTaskContext(tc *TaskContext) DelegateOption {
+	return infraagent.WithDelegateTaskContext(tc)
+}
+
+// WithDelegateRiskLevel sets the risk annotation on the delegate tool.
+func WithDelegateRiskLevel(level RiskLevel) DelegateOption {
+	return infraagent.WithRiskLevel(level)
+}
+
+// NewDelegateTool wraps child as a tool named name for agent composition.
+// Callers pass *api.Engine; no need to import infrastructure/agent.
+func NewDelegateTool(name, description string, child *Engine, opts ...DelegateOption) *DelegateTool {
+	return infraagent.NewDelegateTool(name, description, child.engine, opts...)
+}

--- a/interfaces/api/delegate_test.go
+++ b/interfaces/api/delegate_test.go
@@ -1,0 +1,91 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	api "go.klarlabs.de/agent/interfaces/api"
+)
+
+func TestNewEventStoreAndRunStore(t *testing.T) {
+	t.Parallel()
+
+	es := api.NewEventStore()
+	if es == nil {
+		t.Fatal("NewEventStore() nil")
+	}
+	rs := api.NewRunStore()
+	if rs == nil {
+		t.Fatal("NewRunStore() nil")
+	}
+}
+
+func TestNewArtifactStore(t *testing.T) {
+	t.Parallel()
+
+	store, err := api.NewArtifactStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewArtifactStore: %v", err)
+	}
+	if store == nil {
+		t.Fatal("NewArtifactStore() nil")
+	}
+}
+
+func TestNewExecutorWithOptions(t *testing.T) {
+	t.Parallel()
+
+	ex := api.NewExecutorWithOptions(
+		api.WithExecutorTimeout(2*time.Second),
+		api.WithExecutorMaxConcurrent(2),
+		api.WithExecutorRetryAttempts(1),
+	)
+	if ex == nil {
+		t.Fatal("NewExecutorWithOptions() nil")
+	}
+}
+
+func TestNewDelegateTool(t *testing.T) {
+	t.Parallel()
+
+	childPlanner := api.NewMockPlanner(
+		api.NewTransitionDecision(api.StateExplore, "start"),
+		api.NewTransitionDecision(api.StateDecide, "decide"),
+		api.NewFinishDecision("ok", json.RawMessage(`{"ok":true}`)),
+	)
+	child, err := api.New(api.WithPlanner(childPlanner), api.WithMaxSteps(10))
+	if err != nil {
+		t.Fatalf("child New: %v", err)
+	}
+
+	delegate := api.NewDelegateTool("child", "delegates", child)
+	if delegate.Name() != "child" {
+		t.Fatalf("Name = %q", delegate.Name())
+	}
+
+	parentPlanner := api.NewScriptedPlanner(
+		api.ScriptStep{ExpectState: api.StateIntake, Decision: api.NewTransitionDecision(api.StateExplore, "go")},
+		api.ScriptStep{ExpectState: api.StateExplore, Decision: api.NewCallToolDecision("child", json.RawMessage(`{"goal":"hi"}`), "delegate")},
+		api.ScriptStep{ExpectState: api.StateExplore, Decision: api.NewTransitionDecision(api.StateDecide, "done")},
+		api.ScriptStep{ExpectState: api.StateDecide, Decision: api.NewFinishDecision("done", nil)},
+	)
+
+	parent, err := api.New(
+		api.WithPlanner(parentPlanner),
+		api.WithTool(delegate),
+		api.WithMaxSteps(20),
+	)
+	if err != nil {
+		t.Fatalf("parent New: %v", err)
+	}
+
+	run, err := parent.Run(context.Background(), "parent goal")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if run.Status != api.StatusCompleted {
+		t.Fatalf("status = %s", run.Status)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Optional follow-ups after v0.16.0: soft-reject polish, deeper API seal, docs regen, and Actions Node 24 pins.

## Soft-reject
- Transition soft-reject already existed; **Finish/Fail** now soft-reject the same way when `done`/`failed` is unreachable (e.g. Finish from `explore`)
- New event: `state.transition.rejected` (audit trail)
- `states.md` transition table corrected to match `DefaultTransitions`

## API seal
- `NewEventStore` / `NewRunStore` / `NewArtifactStore`
- `NewDelegateTool` (+ task context / risk options)
- `NewExecutorWithOptions` + `WithExecutorTimeout` / `MaxConcurrent` / `Retry*`
- Planner concrete type aliases on `interfaces/api`

## Docs / CI
- Regenerated `docs/api/*` via `make docs-api`; index notes godoc is source of truth
- Bumped checkout/setup-go/softprops/upload-artifact/setup-node/deploy-pages to Node 24 majors (same SHAs as `provenance.yml` where applicable)

## Note
Reusable org workflows (`ci.yml` / `nox-remediate.yml` callers) still need a klarlabs-studio/.github pin bump separately for full Node 24 coverage.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a004c3-0d63-7667-8815-db3304a4e158?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a004c3-0d63-7667-8815-db3304a4e158&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

