### PR TITLE
chore(release): prepare v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-08-15
+
 ### Added
 - `state.transition.rejected` event when Transition/Finish/Fail targets a
   disallowed state (soft-reject path).
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   state (planner receives Feedback; run continues under loop detection).
 - Concept `states.md` transition table matches `DefaultTransitions`.
 - Regenerated `docs/api/*` from godoc; Actions pins bumped to Node 24 majors.
+- `version.go` → `0.16.1`.
 
 ## [0.16.0] - 2026-08-15
 
@@ -250,7 +253,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - go.opentelemetry.io/otel v1.39.0
 - And various cloud SDKs (AWS, GCP, Azure)
 
-[unreleased]: https://github.com/klarlabs-studio/agent-go/compare/v0.16.0...HEAD
+[unreleased]: https://github.com/klarlabs-studio/agent-go/compare/v0.16.1...HEAD
+[0.16.1]: https://github.com/klarlabs-studio/agent-go/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/klarlabs-studio/agent-go/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/klarlabs-studio/agent-go/releases/tag/v0.15.0
 [0.7.0]: https://github.com/klarlabs-studio/agent-go/compare/v0.6.0...v0.7.0

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@
 package agentgo
 
 // Version is the current version of agent-go.
-const Version = "0.16.0"
+const Version = "0.16.1"
 
 // GetVersion returns the current version string.
 func GetVersion() string {

--- a/version_test.go
+++ b/version_test.go
@@ -10,8 +10,8 @@ func TestVersion(t *testing.T) {
 	}
 
 	// Verify version matches the current release line
-	if Version != "0.16.0" {
-		t.Errorf("Version is %s, expected 0.16.0", Version)
+	if Version != "0.16.1" {
+		t.Errorf("Version is %s, expected 0.16.1", Version)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release prep for **v0.16.1** (ships #99: soft-reject Finish/Fail, API seal constructors, docs regen, Actions Node 24 pins).

## After merge

```bash
git checkout main && git pull
git tag -a v0.16.1 -m "v0.16.1"
git push origin v0.16.1
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a004c3-0d63-7667-8815-db3304a4e158?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a004c3-0d63-7667-8815-db3304a4e158&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

