### PR TITLE
fix(gate): run the integration-tagged tests

### DIFF
--- a/.warden.yaml
+++ b/.warden.yaml
@@ -3,7 +3,14 @@
 hooks: { pre_commit: true, pre_push: true }
 commands:
   lint: "golangci-lint run ./..."
-  test: "go test -race ./..."
+  # -tags=integration so test/integration/ is compiled and run too. Without
+  # it the build tag excludes the package from every automatic run: the gate
+  # skipped it, the shared CI bar skipped it, and `make test-integration` was
+  # the only way it ever executed — when somebody remembered.
+  #
+  # It needs nothing external (in-memory storage, no network) and takes 0.4s,
+  # so there is no reason for it to be optional.
+  test: "go test -race -tags=integration ./..."
 steps:
   pre_commit: [lint]
   pre_push: [test, lint]


### PR DESCRIPTION
`test/integration/full_flow_test.go` is behind `//go:build integration`, so **no automatic run ever compiled it**. The gate ran `go test -race ./...`; the shared CI bar runs the same; `make test-integration` was the only path to it, taken when somebody remembered.

The suite imports nothing outside this module — in-memory storage, no network, no containers — and runs in **0.44 seconds**. There is no cost to justify keeping an end-to-end test of the agent runtime optional.

One flag rather than a new step: `-tags=integration` compiles the tagged package alongside everything else, so one command covers all 56 packages.

Found in a sweep for tests that only run in CI. Most of the fleet came back clean; chronos and mnemos run theirs properly; this one and two others did not.

https://claude.ai/code/session_01N9cWx4ZEypDzzhvnnTiHdy